### PR TITLE
fixed declare_parsec() and define_parsec() macro

### DIFF
--- a/include/cparsec3/parsec/combinator.h
+++ b/include/cparsec3/parsec/combinator.h
@@ -27,7 +27,7 @@
  *
  */
 #define declare_parsec(S, T, ...)                                        \
-  IF(IS_NIL(__VA_ARGS__, ))                                              \
+  IF(IS_NIL(__VA_ARGS__))                                                \
   (declare_parser, declare_combinator)(S, T, __VA_ARGS__)
 
 /**
@@ -50,9 +50,8 @@
  *
  */
 #define define_parsec(S, T, ...)                                         \
-  IF(IS_NIL(__VA_ARGS__, ))                                              \
+  IF(IS_NIL(__VA_ARGS__))                                                \
   (define_parser, define_combinator)(S, T, __VA_ARGS__)
-
 
 // -----------------------------------------------------------------------
 #define PARAMETERS(...)                                                  \


### PR DESCRIPTION
fixed the following 
- `declare_parsec(S, T, name)` was expanded to `declare_combinator(S, T, name)` instead of `declare_parser(S, T, name)`
- `define_parsec(S, T, name)` was expanded to `define_combinator(S, T, name)` instead of `define_parser(S, T, name)`
