### PR TITLE
added instance_Eq(T, _eq_) and instance_Ord(T, ...) macros

### DIFF
--- a/include/cparsec3/base/eq.h
+++ b/include/cparsec3/base/eq.h
@@ -6,6 +6,7 @@
 #include "typeset.h"
 
 #define Eq(T) TYPE_NAME(Eq, T)
+// -----------------------------------------------------------------------
 #define trait_Eq(T)                                                      \
   C_API_BEGIN                                                            \
   typedef struct {                                                       \
@@ -16,4 +17,20 @@
   C_API_END                                                              \
   END_OF_STATEMENTS
 
+// -----------------------------------------------------------------------
+#define instance_Eq(T, _eq_)                                             \
+  C_API_BEGIN                                                            \
+  static bool FUNC_NAME(neq, Eq(T))(T a, T b) {                          \
+    return !_eq_(a, b);                                                  \
+  }                                                                      \
+  Eq(T) Trait(Eq(T)) {                                                   \
+    return (Eq(T)){                                                      \
+        .eq = _eq_,                                                      \
+        .neq = FUNC_NAME(neq, Eq(T)),                                    \
+    };                                                                   \
+  }                                                                      \
+  C_API_END                                                              \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
 FOREACH(trait_Eq, TYPESET(ALL));

--- a/include/cparsec3/base/maybe.h
+++ b/include/cparsec3/base/maybe.h
@@ -40,8 +40,7 @@
 // -----------------------------------------------------------------------
 #define impl_Maybe(T)                                                    \
   C_API_BEGIN                                                            \
-  impl_Eq_Maybe(T);                                                      \
-  impl_Ord_Maybe(T);                                                     \
+  /* ---- trait Maybe(T) */                                              \
   static Maybe(T) FUNC_NAME(just, Maybe(T))(T value) {                   \
     return (Maybe(T)){.value = value};                                   \
   }                                                                      \
@@ -54,11 +53,7 @@
         .none = FUNC_NAME(none, Maybe(T)),                               \
     };                                                                   \
   }                                                                      \
-  C_API_END                                                              \
-  END_OF_STATEMENTS
-
-// -----------------------------------------------------------------------
-#define impl_Eq_Maybe(T)                                                 \
+  /* ---- instance Eq(Maybe(T)) */                                       \
   static bool FUNC_NAME(eq, Maybe(T))(Maybe(T) a, Maybe(T) b) {          \
     if (a.none && b.none) {                                              \
       return true;                                                       \
@@ -68,19 +63,8 @@
     }                                                                    \
     return trait(Eq(T)).eq(a.value, b.value);                            \
   }                                                                      \
-  static bool FUNC_NAME(neq, Maybe(T))(Maybe(T) a, Maybe(T) b) {         \
-    return !FUNC_NAME(eq, Maybe(T))(a, b);                               \
-  }                                                                      \
-  Eq(Maybe(T)) Trait(Eq(Maybe(T))) {                                     \
-    return (Eq(Maybe(T))){                                               \
-        .eq = FUNC_NAME(eq, Maybe(T)),                                   \
-        .neq = FUNC_NAME(neq, Maybe(T)),                                 \
-    };                                                                   \
-  }                                                                      \
-  END_OF_STATEMENTS
-
-// -----------------------------------------------------------------------
-#define impl_Ord_Maybe(T)                                                \
+  instance_Eq(Maybe(T), FUNC_NAME(eq, Maybe(T)));                        \
+  /* ---- instance Ord(Maybe(T)) */                                      \
   static bool FUNC_NAME(le, Maybe(T))(Maybe(T) a, Maybe(T) b) {          \
     if (a.none) {                                                        \
       return true;                                                       \
@@ -90,38 +74,10 @@
     }                                                                    \
     return trait(Ord(T)).le(a.value, b.value);                           \
   }                                                                      \
-  static bool FUNC_NAME(lt, Maybe(T))(Maybe(T) a, Maybe(T) b) {          \
-    return FUNC_NAME(le, Maybe(T))(a, b) &&                              \
-           !FUNC_NAME(eq, Maybe(T))(a, b);                               \
-  }                                                                      \
-  static bool FUNC_NAME(ge, Maybe(T))(Maybe(T) a, Maybe(T) b) {          \
-    return FUNC_NAME(le, Maybe(T))(b, a);                                \
-  }                                                                      \
-  static bool FUNC_NAME(gt, Maybe(T))(Maybe(T) a, Maybe(T) b) {          \
-    return FUNC_NAME(lt, Maybe(T))(b, a);                                \
-  }                                                                      \
-  static int FUNC_NAME(cmp, Maybe(T))(Maybe(T) a, Maybe(T) b) {          \
-    return (FUNC_NAME(le, Maybe(T))(a, b)                                \
-                ? (FUNC_NAME(eq, Maybe(T))(a, b) ? 0 : -1)               \
-                : 1);                                                    \
-  }                                                                      \
-  static Maybe(T) FUNC_NAME(min, Maybe(T))(Maybe(T) a, Maybe(T) b) {     \
-    return FUNC_NAME(le, Maybe(T))(a, b) ? a : b;                        \
-  }                                                                      \
-  static Maybe(T) FUNC_NAME(max, Maybe(T))(Maybe(T) a, Maybe(T) b) {     \
-    return FUNC_NAME(le, Maybe(T))(b, a) ? a : b;                        \
-  }                                                                      \
-  Ord(Maybe(T)) Trait(Ord(Maybe(T))) {                                   \
-    return (Ord(Maybe(T))){                                              \
-        .cmp = FUNC_NAME(cmp, Maybe(T)),                                 \
-        .lt = FUNC_NAME(lt, Maybe(T)),                                   \
-        .le = FUNC_NAME(le, Maybe(T)),                                   \
-        .gt = FUNC_NAME(gt, Maybe(T)),                                   \
-        .ge = FUNC_NAME(ge, Maybe(T)),                                   \
-        .min = FUNC_NAME(min, Maybe(T)),                                 \
-        .max = FUNC_NAME(max, Maybe(T)),                                 \
-    };                                                                   \
-  }                                                                      \
+  instance_Ord(Maybe(T), FUNC_NAME(le, Maybe(T)),                        \
+               FUNC_NAME(eq, Maybe(T)));                                 \
+  /* ---- */                                                             \
+  C_API_END                                                              \
   END_OF_STATEMENTS
 
 // -----------------------------------------------------------------------

--- a/include/cparsec3/base/ord.h
+++ b/include/cparsec3/base/ord.h
@@ -6,6 +6,7 @@
 #include "typeset.h"
 
 #define Ord(T) TYPE_NAME(Ord, T)
+// -----------------------------------------------------------------------
 #define trait_Ord(T)                                                     \
   C_API_BEGIN                                                            \
   typedef struct {                                                       \
@@ -36,4 +37,76 @@
   C_API_END                                                              \
   END_OF_STATEMENTS
 
+// -----------------------------------------------------------------------
+#define instance_Ord(T, ...)                                             \
+  CAT(instance_Ord_, VARIADIC_SIZE(__VA_ARGS__))(T, __VA_ARGS__)
+
+#define instance_Ord_1 instance_Ord_cmp
+#define instance_Ord_2 instance_Ord_le_eq
+
+// -----------------------------------------------------------------------
+#define instance_Ord_cmp(T, _cmp_)                                       \
+  static bool FUNC_NAME(lt, T)(T a, T b) {                               \
+    return _cmp_(a, b) < 0;                                              \
+  }                                                                      \
+  static bool FUNC_NAME(le, T)(T a, T b) {                               \
+    return _cmp_(a, b) <= 0;                                             \
+  }                                                                      \
+  static bool FUNC_NAME(gt, T)(T a, T b) {                               \
+    return _cmp_(a, b) > 0;                                              \
+  }                                                                      \
+  static bool FUNC_NAME(ge, T)(T a, T b) {                               \
+    return _cmp_(a, b) >= 0;                                             \
+  }                                                                      \
+  static T FUNC_NAME(min, T)(T a, T b) {                                 \
+    return _cmp_(a, b) <= 0 ? a : b;                                     \
+  }                                                                      \
+  static T FUNC_NAME(max, T)(T a, T b) {                                 \
+    return _cmp_(a, b) >= 0 ? a : b;                                     \
+  }                                                                      \
+  Ord(T) Trait(Ord(T)) {                                                 \
+    return (Ord(T)){.cmp = _cmp_,                                        \
+                    .lt = FUNC_NAME(lt, T),                              \
+                    .le = FUNC_NAME(le, T),                              \
+                    .gt = FUNC_NAME(gt, T),                              \
+                    .ge = FUNC_NAME(ge, T),                              \
+                    .min = FUNC_NAME(min, T),                            \
+                    .max = FUNC_NAME(max, T)};                           \
+  }                                                                      \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define instance_Ord_le_eq(T, _le_, _eq_)                                \
+  static int FUNC_NAME(cmp, T)(T a, T b) {                               \
+    return (_le_(a, b) ? (_eq_(a, b) ? 0 : -1) : 1);                     \
+  }                                                                      \
+  static bool FUNC_NAME(lt, T)(T a, T b) {                               \
+    return _le_(a, b) && !_eq_(a, b);                                    \
+  }                                                                      \
+  static bool FUNC_NAME(ge, T)(T a, T b) {                               \
+    return _le_(b, a);                                                   \
+  }                                                                      \
+  static bool FUNC_NAME(gt, T)(T a, T b) {                               \
+    return FUNC_NAME(lt, T)(b, a);                                       \
+  }                                                                      \
+  static T FUNC_NAME(min, T)(T a, T b) {                                 \
+    return _le_(a, b) ? a : b;                                           \
+  }                                                                      \
+  static T FUNC_NAME(max, T)(T a, T b) {                                 \
+    return _le_(b, a) ? a : b;                                           \
+  }                                                                      \
+  Ord(T) Trait(Ord(T)) {                                                 \
+    return (Ord(T)){                                                     \
+        .cmp = FUNC_NAME(cmp, T),                                        \
+        .lt = FUNC_NAME(lt, T),                                          \
+        .le = _le_,                                                      \
+        .gt = FUNC_NAME(gt, T),                                          \
+        .ge = FUNC_NAME(ge, T),                                          \
+        .min = FUNC_NAME(min, T),                                        \
+        .max = FUNC_NAME(max, T),                                        \
+    };                                                                   \
+  }                                                                      \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
 FOREACH(trait_Ord, TYPESET(ALL));

--- a/src/cparsec3/base/eq.c
+++ b/src/cparsec3/base/eq.c
@@ -28,21 +28,9 @@ static bool EQ(None)(None a, None b) {
   UNUSED(b);
   return true;
 }
-static bool NEQ(None)(None a, None b) {
-  UNUSED(a);
-  UNUSED(b);
-  return false;
-}
-Eq(None) Trait(Eq(None)) {
-  return (Eq(None)){.eq = EQ(None), .neq = NEQ(None)};
-}
+instance_Eq(None, EQ(None));
 
 static bool EQ(String)(String a, String b) {
   return !strcmp(a, b);
 }
-static bool NEQ(String)(String a, String b) {
-  return !!strcmp(a, b);
-}
-Eq(String) Trait(Eq(String)) {
-  return (Eq(String)){.eq = EQ(String), .neq = NEQ(String)};
-}
+instance_Eq(String, EQ(String));

--- a/src/cparsec3/base/ord.c
+++ b/src/cparsec3/base/ord.c
@@ -55,72 +55,10 @@ static int CMP(None)(None a, None b) {
   UNUSED(b);
   return 0;
 }
-static bool LT(None)(None a, None b) {
-  UNUSED(a);
-  UNUSED(b);
-  return false;
-}
-static bool LE(None)(None a, None b) {
-  UNUSED(a);
-  UNUSED(b);
-  return true;
-}
-static bool GT(None)(None a, None b) {
-  UNUSED(a);
-  UNUSED(b);
-  return false;
-}
-static bool GE(None)(None a, None b) {
-  UNUSED(a);
-  UNUSED(b);
-  return true;
-}
-static None MIN(None)(None a, None b) {
-  UNUSED(b);
-  return a;
-}
-static None MAX(None)(None a, None b) {
-  UNUSED(b);
-  return a;
-}
-Ord(None) Trait(Ord(None)) {
-  return (Ord(None)){.cmp = CMP(None),
-                     .lt = LT(None),
-                     .le = LE(None),
-                     .gt = GT(None),
-                     .ge = GE(None),
-                     .min = MIN(None),
-                     .max = MAX(None)};
-}
+instance_Ord(None, CMP(None));
 
 static int CMP(String)(String a, String b) {
   int x = strcmp(a, b);
   return (x <= 0 ? (x == 0 ? 0 : -1) : 1);
 }
-static bool LT(String)(String a, String b) {
-  return CMP(String)(a, b) < 0;
-}
-static bool LE(String)(String a, String b) {
-  return CMP(String)(a, b) <= 0;
-}
-static bool GT(String)(String a, String b) {
-  return CMP(String)(a, b) > 0;
-}
-static bool GE(String)(String a, String b) {
-  return CMP(String)(a, b) >= 0;
-}
-static String MIN(String)(String a, String b) {
-  return LE(String)(a, b) ? a : b;
-}
-static String MAX(String)(String a, String b) {
-  return LE(String)(b, a) ? a : b;
-}
-Ord(String) Trait(Ord(String)) {
-  return (Ord(String)){.cmp = CMP(String),
-                       .lt = LT(String),
-                       .le = LE(String),
-                       .gt = GT(String),
-                       .ge = GE(String),
-                       .min = MIN(String),
-                       .max = MAX(String)};
-}
+instance_Ord(String, CMP(String));


### PR DESCRIPTION
For easy to implement `Eq(T)` and `Ord(T)`, added the following macros:
- `instance_Eq(T, _eq_)`
- `instance_Ord(T, _le_, _eq_)`
- `instance_Ord(T, _cmp_)`