### PR TITLE
fixed some members of ArrayT(T), ListT(T), MaybeT(T) traits.

### DIFF
--- a/docs/api-base.org
+++ b/docs/api-base.org
@@ -138,7 +138,16 @@ An ~MemT(T)~ trait provides the following member functions :
      Constructs a new trait of ~ArrayT(T)~ type.\\
      For example, ~trait(Array(int))~ creates an object of ~ArrayT(int)~ type.
 
-An ~ArrayT(T)~ trait provides the following member functions :
+An ~ArrayT(T)~ trait provides the following member variables/functions :
+- Array(T) empty         ::
+     An empty array.\\
+     i.e. 0-length array.
+- bool null(Array(T) a) ::
+     Returns ~true~ if length of the array ~a~ was 0, ~false~ otherwise.\\
+     i.e. returns ~!a.length~
+- size_t length(Array(T) a) ::
+     Returns the length of the array ~a~.\\
+     i.e. returns ~a.length~.
 - Array(T) create(size_t n) ::
      Constructs an array of length ~n~.
 - void free(Array(T) a) ::
@@ -150,18 +159,12 @@ An ~ArrayT(T)~ trait provides the following member functions :
 - T* end(Array(T) a) ::
      Returns the out of bounds address over the last element of the array ~a~.\\
      i.e. returns ~a.data + a.length~.
-- size_t length(Array(T) a) ::
-     Returns the length of the array ~a~.\\
-     i.e. returns ~a.length~.
-- bool empty(Array(T) a) ::
-     Returns ~true~ if length of the array ~a~ was 0, ~false~ otherwise.\\
-     i.e. returns ~!a.length~
 
 *** ListT(T) - trait for List(T) container.
 
 #+begin_src c
   ListT(int) m = trait(List(int));
-  List(int) xs = m.cons(1, m.cons(2, m.cons(3, m.nil())));
+  List(int) xs = m.cons(1, m.cons(2, m.cons(3, m.empty)));
   for (List(int) ys = xs; !m.null(ys); ys = m.tail(ys)) {
     printf("%d ", m.head(ys));    /* -> 1 2 3 */
   }
@@ -176,11 +179,17 @@ An ~ArrayT(T)~ trait provides the following member functions :
      Constructs a new trait of ~ListT(T)~ type.\\
      For example, ~trait(List(int))~ creates an object of ~ListT(int)~ type.
 
-An ~ListT(T)~ trait provides the following member functions :
+An ~ListT(T)~ trait provides the following member variables/functions :
+- List(T) empty         ::
+     An empty list.\\
+     i.e. ~NULL~
+- bool null(List(T) xs) ::
+     Returns ~true~ if the list ~xs~ was ~NULL~, ~false~ otherwise.\\
+     i.e. returns ~!xs~.
+- size_t length(List(T) xs) ::
+     Returns length of the list ~xs~.
 - List(T) cons(T x, List(T) xs) ::
      Constructs a linked-list (cons-cell).
-- List(T) nil(void) ::
-     Constructs an empty list.
 - void free(List(T) xs) ::
      Destructs all cells of the list ~xs~.
 - List(T) drop(size_t n, List(T) xs) ::
@@ -192,9 +201,47 @@ An ~ListT(T)~ trait provides the following member functions :
 - List(T) tail(List(T) xs) ::
      Returns the tail list of the list ~xs~.\\
      i.e. returns ~xs->tail~.
-- bool null(List(T) xs) ::
-     Returns ~true~ if the list ~xs~ was ~NULL~, ~false~ otherwise.\\
-     i.e. returns ~!xs~.
+
+*** MaybeT(T) - trait for Maybe(T) container.
+
+#+begin_src c
+  /* MaybeT(int) is a trait type to construct and manipulate Maybe(T) */
+  MaybeT(int) M = trait(Maybe(int));
+
+  Maybe(int) m = M.just(5);
+  assert(M.length(m) == 1);
+  assert(!M.null(m));
+  assert(!m.none);
+  assert(m.value == 5);
+
+  Maybe(int) e = M.empty;
+  assert(M.length(e) == 0);
+  assert(M.null(e));
+  assert(e.none);
+  int x = e.value; // undefined behaviour
+#+end_src
+
+- MaybeT(T)       ::
+     Type of a trait that provides a set of functions to construct and
+     manipulate ~Maybe(T)~.
+
+- trait(Maybe(T))   :: 
+     Constructs a new trait of ~MaybeT(T)~ type.\\
+     For example, ~trait(Maybe(int))~ creates an object of ~MaybeT(int)~ type.
+
+A ~MaybeT(T)~ trait provides the following member variables/functions :
+- Maybe(T) empty         ::
+     An object that represents nothing.\\
+     i.e. ~empty.none~ \equal ~true~.
+- bool null(Maybe(T) m) ::
+     Returns ~true~ if the ~m~ was nothing, ~false~ otherwise.\\
+     i.e. returns ~m.none~
+- size_t length(Maybe(T) m) ::
+     Returns 0 if the ~m~ was nothing, 1 otherwise.\\
+     i.e. returns ~(m.none ? 0 : 1)~.
+- Maybe(T) just(T value) ::
+     Constructs a Maybe(T) object that represents the ~value~.\\
+     i.e. returns ~(Maybe(T)){.none = false, .value = value}~.
 
 *** Show(T) - trait to represent a value as a string
 

--- a/include/cparsec3/base/array.h
+++ b/include/cparsec3/base/array.h
@@ -20,12 +20,13 @@
   C_API_BEGIN                                                            \
   typedef_Array(T);                                                      \
   typedef struct {                                                       \
+    Array(T) empty;                                                      \
+    bool (*null)(Array(T) a);                                            \
+    size_t (*length)(Array(T) a);                                        \
     Array(T) (*create)(size_t n);                                        \
     void (*free)(Array(T) a);                                            \
     T* (*begin)(Array(T) a);                                             \
     T* (*end)(Array(T) a);                                               \
-    size_t (*length)(Array(T) a);                                        \
-    bool (*empty)(Array(T) a);                                           \
   } ArrayT(T);                                                           \
   ArrayT(T) Trait(Array(T));                                             \
   C_API_END                                                              \
@@ -34,6 +35,12 @@
 // -----------------------------------------------------------------------
 #define impl_Array(T)                                                    \
   C_API_BEGIN                                                            \
+  static bool FUNC_NAME(null, Array(T))(Array(T) a) {                    \
+    return !a.length;                                                    \
+  }                                                                      \
+  static size_t FUNC_NAME(length, Array(T))(Array(T) a) {                \
+    return a.length;                                                     \
+  }                                                                      \
   static Array(T) FUNC_NAME(create, Array(T))(size_t n) {                \
     return (Array(T)){.length = n, .data = trait(Mem(T)).create(n)};     \
   }                                                                      \
@@ -46,19 +53,16 @@
   static T* FUNC_NAME(end, Array(T))(Array(T) a) {                       \
     return a.data + a.length;                                            \
   }                                                                      \
-  static size_t FUNC_NAME(length, Array(T))(Array(T) a) {                \
-    return a.length;                                                     \
-  }                                                                      \
-  static bool FUNC_NAME(empty, Array(T))(Array(T) a) {                   \
-    return !a.length;                                                    \
-  }                                                                      \
   ArrayT(T) Trait(Array(T)) {                                            \
-    return (ArrayT(T)){.create = FUNC_NAME(create, Array(T)),            \
-                       .free = FUNC_NAME(free, Array(T)),                \
-                       .begin = FUNC_NAME(begin, Array(T)),              \
-                       .end = FUNC_NAME(end, Array(T)),                  \
-                       .length = FUNC_NAME(length, Array(T)),            \
-                       .empty = FUNC_NAME(empty, Array(T))};             \
+    return (ArrayT(T)){                                                  \
+        .empty = {0},                                                    \
+        .null = FUNC_NAME(null, Array(T)),                               \
+        .length = FUNC_NAME(length, Array(T)),                           \
+        .create = FUNC_NAME(create, Array(T)),                           \
+        .free = FUNC_NAME(free, Array(T)),                               \
+        .begin = FUNC_NAME(begin, Array(T)),                             \
+        .end = FUNC_NAME(end, Array(T)),                                 \
+    };                                                                   \
   }                                                                      \
   C_API_END                                                              \
   END_OF_STATEMENTS

--- a/include/cparsec3/base/list.h
+++ b/include/cparsec3/base/list.h
@@ -25,13 +25,14 @@
   C_API_BEGIN                                                            \
   typedef_List(T);                                                       \
   typedef struct {                                                       \
+    List(T) empty;                                                       \
+    bool (*null)(List(T) xs);                                            \
+    size_t (*length)(List(T) xs);                                        \
     List(T) (*cons)(T x, List(T) xs);                                    \
-    List(T) (*nil)(void);                                                \
     void (*free)(List(T) xs);                                            \
     List(T) (*drop)(size_t n, List(T) xs);                               \
     T (*head)(List(T) xs);                                               \
     List(T) (*tail)(List(T) xs);                                         \
-    bool (*null)(List(T) xs);                                            \
   } ListT(T);                                                            \
   ListT(T) Trait(List(T));                                               \
   C_API_END                                                              \
@@ -42,14 +43,21 @@
   C_API_BEGIN                                                            \
   trait_Mem(stList(T));                                                  \
   impl_Mem(stList(T));                                                   \
+  static bool FUNC_NAME(null, List(T))(List(T) xs) {                     \
+    return !xs;                                                          \
+  }                                                                      \
+  static size_t FUNC_NAME(length, List(T))(List(T) xs) {                 \
+    size_t len = 0;                                                      \
+    for (; xs; xs = xs->tail) {                                          \
+      len++;                                                             \
+    }                                                                    \
+    return len;                                                          \
+  }                                                                      \
   static List(T) FUNC_NAME(cons, List(T))(T x, List(T) xs) {             \
     List(T) ys = trait(Mem(stList(T))).create(1);                        \
     ys->head = x;                                                        \
     ys->tail = xs;                                                       \
     return ys;                                                           \
-  }                                                                      \
-  static List(T) FUNC_NAME(nil, List(T))(void) {                         \
-    return NULL;                                                         \
   }                                                                      \
   static void FUNC_NAME(free, List(T))(List(T) xs) {                     \
     while (xs) {                                                         \
@@ -75,18 +83,16 @@
   static List(T) FUNC_NAME(tail, List(T))(List(T) xs) {                  \
     return xs->tail;                                                     \
   }                                                                      \
-  static bool FUNC_NAME(null, List(T))(List(T) xs) {                     \
-    return !xs;                                                          \
-  }                                                                      \
   ListT(T) Trait(List(T)) {                                              \
     return (ListT(T)){                                                   \
+        .empty = NULL,                                                   \
+        .null = FUNC_NAME(null, List(T)),                                \
+        .length = FUNC_NAME(length, List(T)),                            \
         .cons = FUNC_NAME(cons, List(T)),                                \
-        .nil = FUNC_NAME(nil, List(T)),                                  \
         .free = FUNC_NAME(free, List(T)),                                \
         .drop = FUNC_NAME(drop, List(T)),                                \
         .head = FUNC_NAME(head, List(T)),                                \
         .tail = FUNC_NAME(tail, List(T)),                                \
-        .null = FUNC_NAME(null, List(T)),                                \
     };                                                                   \
   }                                                                      \
   C_API_END                                                              \

--- a/include/cparsec3/base/maybe.h
+++ b/include/cparsec3/base/maybe.h
@@ -27,11 +27,10 @@
   trait_Eq(Maybe(T));                                                    \
   trait_Ord(Maybe(T));                                                   \
   typedef struct {                                                       \
+    Maybe(T) empty;                                                      \
+    bool (*null)(Maybe(T) m);                                            \
+    size_t (*length)(Maybe(T) m);                                        \
     Maybe(T) (*just)(T value);                                           \
-    union {                                                              \
-      Maybe(T) (*none)(void);                                            \
-      Maybe(T) (*nothing)(void);                                         \
-    };                                                                   \
   } MaybeT(T);                                                           \
   MaybeT(T) Trait(Maybe(T));                                             \
   C_API_END                                                              \
@@ -41,16 +40,21 @@
 #define impl_Maybe(T)                                                    \
   C_API_BEGIN                                                            \
   /* ---- trait Maybe(T) */                                              \
+  static bool FUNC_NAME(null, Maybe(T))(Maybe(T) m) {                    \
+    return m.none;                                                       \
+  }                                                                      \
+  static size_t FUNC_NAME(length, Maybe(T))(Maybe(T) m) {                \
+    return m.none ? 0 : 1;                                               \
+  }                                                                      \
   static Maybe(T) FUNC_NAME(just, Maybe(T))(T value) {                   \
     return (Maybe(T)){.value = value};                                   \
   }                                                                      \
-  static Maybe(T) FUNC_NAME(none, Maybe(T))(void) {                      \
-    return (Maybe(T)){.none = true};                                     \
-  }                                                                      \
   MaybeT(T) Trait(Maybe(T)) {                                            \
     return (MaybeT(T)){                                                  \
+        .empty = {0},                                                    \
+        .null = FUNC_NAME(null, Maybe(T)),                               \
+        .length = FUNC_NAME(length, Maybe(T)),                           \
         .just = FUNC_NAME(just, Maybe(T)),                               \
-        .none = FUNC_NAME(none, Maybe(T)),                               \
     };                                                                   \
   }                                                                      \
   /* ---- instance Eq(Maybe(T)) */                                       \


### PR DESCRIPTION
- added `empty` member variable that represents empty container.
  - `trait(Array(T)).empty` is an empty array of `T` type.
  - `trait(List(T)).empty` is an empty list. (i.e. `NULL`)
  - `trait(Maybe(T)).empty` is an object that represents **nothing**.

- added `null(x)` member function that replaces `empty(x)`.
  - `trait(Array(T)).null(a)` tests whether `a` was empty or not.
  - `trait(List(T)).null(xs)` tests whether `xs` was `NULL` or not.
  - `trait(Maybe(T)).null(m)` tests whether `m` was **nothing** or not.

- added `length(x)` member function.
  - `trait(Array(T)).length(a)` returns the length of `a`.
  - `trait(List(T)).length(xs)` returns the length of `xs`.
  - `trait(Maybe(T)).length(m)` returns the length of `m`. (0 or 1)

- removed `nil()` member function of ListT(T). Use `empty` instead.
- removed `empty(a)` member function of ArrayT(T). Use `null(a)` instead.
- removed `none()` and `nothing()` of MaybeT(T). Use `empty` instead.