### PR TITLE
Feature/base/generics macro

### DIFF
--- a/example/base/.project.mk
+++ b/example/base/.project.mk
@@ -1,0 +1,10 @@
+# -*- coding: utf-8-unix -*-
+TARGET = bin/ex-base
+
+CFLAGS   += -D_POSIX_C_SOURCE
+CFLAGS   += -std=c11 -I include -I ../../include
+LDFLAGS  += -L ../../lib
+LDLIBS   += -lcparsec3
+
+depend:
+	$(MAKE) lib -C ../..

--- a/example/base/GNUmakefile
+++ b/example/base/GNUmakefile
@@ -1,0 +1,2 @@
+# -*- coding:utf-8-unix -*-
+include ../../GNUmakefile

--- a/example/base/src/main.c
+++ b/example/base/src/main.c
@@ -1,0 +1,51 @@
+/* -*- coding: utf-8-unix -*- */
+// #include <cparsec3/base/base.h>
+#include <cparsec3/base/base_generics.h>
+
+void test1(void) {
+  Array(int) a = g_array(int, 1, 2, 3, 4, 5);
+  printf("length(a) = %zu\n", g_length(a));
+  for (int* it = g_begin(a); it != g_end(a); it++) {
+    printf("%d ", *it);
+  }
+  printf("\n");
+  g_free(a);
+}
+
+void test2(void) {
+  Array(String) a = g_array(String, "a", "b", "c");
+  printf("length(a) = %zu\n", g_length(a));
+  for (String* it = g_begin(a); it != g_end(a); it++) {
+    printf("\"%s\" ", *it);
+  }
+  printf("\n");
+  g_free(a);
+}
+
+void test3(void) {
+  List(int) xs = g_list(int, 1, 2, 3, 4, 5, 6);
+  printf("length(xs) = %zu\n", g_length(xs));
+  for (List(int) ys = xs; !g_null(ys); ys = g_tail(ys)) {
+    printf("%d ", g_head(ys));
+  }
+  printf("\n");
+  g_free(xs);
+}
+
+void test4(void) {
+  List(String) xs = g_list(String, "a", "b", "c");
+  printf("length(xs) = %zu\n", g_length(xs));
+  for (List(String) ys = xs; !g_null(ys); ys = g_tail(ys)) {
+    printf("\"%s\" ", g_head(ys));
+  }
+  printf("\n");
+  g_free(xs);
+}
+
+int main(void) {
+  test1();
+  test2();
+  test3();
+  test4();
+  return 0;
+}

--- a/include/cparsec3/ParsecString.h
+++ b/include/cparsec3/ParsecString.h
@@ -16,4 +16,4 @@
 #include "specialize/specialize.h"
 
 // -------------------------------------------------------------
-CPARSEC_DECLARE_ALL(String);
+//CPARSEC_DECLARE_ALL(String);

--- a/include/cparsec3/base/array.h
+++ b/include/cparsec3/base/array.h
@@ -2,6 +2,11 @@
 #pragma once
 
 #include "common.h"
+#include "trait.h"
+#include "typeset.h"
+
+#include "eq.h"
+#include "ord.h"
 
 #define Array(T) TYPE_NAME(Array, T)
 #define ArrayT(T) TYPE_NAME(ArrayT, T)
@@ -19,10 +24,13 @@
 #define trait_Array(T)                                                   \
   C_API_BEGIN                                                            \
   typedef_Array(T);                                                      \
+  trait_Eq(Array(T));                                                    \
+  trait_Ord(Array(T));                                                   \
   typedef struct {                                                       \
     Array(T) empty;                                                      \
     bool (*null)(Array(T) a);                                            \
     size_t (*length)(Array(T) a);                                        \
+    Array(T) (*from_array)(size_t n, T* a);                              \
     Array(T) (*create)(size_t n);                                        \
     void (*free)(Array(T) a);                                            \
     T* (*begin)(Array(T) a);                                             \
@@ -35,6 +43,7 @@
 // -----------------------------------------------------------------------
 #define impl_Array(T)                                                    \
   C_API_BEGIN                                                            \
+  /* ---- trait Array(T) */                                              \
   static bool FUNC_NAME(null, Array(T))(Array(T) a) {                    \
     return !a.length;                                                    \
   }                                                                      \
@@ -43,6 +52,13 @@
   }                                                                      \
   static Array(T) FUNC_NAME(create, Array(T))(size_t n) {                \
     return (Array(T)){.length = n, .data = trait(Mem(T)).create(n)};     \
+  }                                                                      \
+  static Array(T) FUNC_NAME(from_array, Array(T))(size_t n, T * a) {     \
+    Array(T) x = FUNC_NAME(create, Array(T))(n);                         \
+    for (size_t i = 0; i < n; i++) {                                     \
+      x.data[i] = a[i];                                                  \
+    }                                                                    \
+    return x;                                                            \
   }                                                                      \
   static void FUNC_NAME(free, Array(T))(Array(T) a) {                    \
     trait(Mem(T)).free(a.data);                                          \
@@ -59,10 +75,46 @@
         .null = FUNC_NAME(null, Array(T)),                               \
         .length = FUNC_NAME(length, Array(T)),                           \
         .create = FUNC_NAME(create, Array(T)),                           \
+        .from_array = FUNC_NAME(from_array, Array(T)),                   \
         .free = FUNC_NAME(free, Array(T)),                               \
         .begin = FUNC_NAME(begin, Array(T)),                             \
         .end = FUNC_NAME(end, Array(T)),                                 \
     };                                                                   \
   }                                                                      \
+  /* ---- instance Eq(Array(T)) */                                       \
+  static bool FUNC_NAME(eq, Array(T))(Array(T) a, Array(T) b) {          \
+    if (a.length != b.length) {                                          \
+      return false;                                                      \
+    }                                                                    \
+    if (a.data == b.data) {                                              \
+      return true;                                                       \
+    }                                                                    \
+    for (size_t i = 0; i < a.length; ++i) {                              \
+      if (trait(Eq(T)).neq(a.data[i], b.data[i])) {                      \
+        return false;                                                    \
+      }                                                                  \
+    }                                                                    \
+    return true;                                                         \
+  }                                                                      \
+  instance_Eq(Array(T), FUNC_NAME(eq, Array(T)));                        \
+  /* ---- instance Ord(Array(T)) */                                      \
+  static int FUNC_NAME(cmp, Array(T))(Array(T) a, Array(T) b) {          \
+    if (a.data == b.data) {                                              \
+      return trait(Ord(uint64_t)).cmp(a.length, b.length);               \
+    }                                                                    \
+    size_t n = (a.length <= b.length ? a.length : b.length);             \
+    for (size_t i = 0; i < n; ++i) {                                     \
+      int o = trait(Ord(T)).cmp(a.data[i], b.data[i]);                   \
+      if (o) {                                                           \
+        return o;                                                        \
+      }                                                                  \
+    }                                                                    \
+    return (a.length < b.length ? -1 : 1);                               \
+  }                                                                      \
+  instance_Ord(Array(T), FUNC_NAME(cmp, Array(T)));                      \
+  /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+// FOREACH(trait_Array, TYPESET(ALL));

--- a/include/cparsec3/base/base.h
+++ b/include/cparsec3/base/base.h
@@ -7,15 +7,41 @@
 #include "none.h"
 #include "typeset.h"
 
-#include "array.h"
-#include "list.h"
-#include "mem.h"
-
-#include "data.h"
-
 #include "eq.h"
 #include "ord.h"
 
+#include "mem.h"
+
+#include "array.h"
+#include "list.h"
 #include "maybe.h"
+
 #include "result.h"
 #include "tuple.h"
+
+#include "data.h"
+
+FOREACH(trait_Mem, TYPESET(ALL));
+FOREACH(trait_Array, TYPESET(ALL));
+FOREACH(trait_List, TYPESET(ALL));
+FOREACH(trait_Maybe, TYPESET(ALL));
+
+FOREACH(trait_Mem,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(trait_Array,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(trait_List,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(trait_Maybe,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));

--- a/include/cparsec3/base/base_generics.h
+++ b/include/cparsec3/base/base_generics.h
@@ -1,0 +1,50 @@
+/* -*- coding: utf-8-unix -*- */
+#pragma once
+
+#include "base.h"
+
+#define CREATE_TRAIT(...) trait(TYPE_NAME(__VA_ARGS__))
+
+// clang-format off
+#define BIND_TYPESET(CONTAINER)                                          \
+  BIND(CONTAINER, TYPESET(ALL),                                          \
+       APPLY(Array, TYPESET(ALL)),                                       \
+       APPLY(List, TYPESET(ALL)),                                        \
+       APPLY(Maybe, TYPESET(ALL)))                                       \
+// clang-format on
+
+// clang-format off
+#define GENERIC_TRAIT(x)                                                 \
+  GENERIC(x, TYPE_NAME, CREATE_TRAIT,                                    \
+          BIND_TYPESET(Array),                                           \
+          BIND_TYPESET(List),                                            \
+          BIND_TYPESET(Maybe))
+// clang-format on
+
+#define GENERIC_TRAIT_ARRAY(x)                                           \
+  GENERIC(x, TYPE_NAME, CREATE_TRAIT, BIND_TYPESET(Array))
+
+#define GENERIC_TRAIT_LIST(x)                                            \
+  GENERIC(x, TYPE_NAME, CREATE_TRAIT, BIND_TYPESET(List))
+
+#define g_length(x) GENERIC_TRAIT(x).length(x)
+#define g_null(x) GENERIC_TRAIT(x).null(x)
+#define g_free(x) GENERIC_TRAIT(x).free(x)
+
+#define g_begin(x) GENERIC_TRAIT_ARRAY(x).begin(x)
+#define g_end(x) GENERIC_TRAIT_ARRAY(x).end(x)
+
+#define g_cons(x, xs) GENERIC_TRAIT_LIST(xs).cons(x, xs)
+#define g_head(xs) GENERIC_TRAIT_LIST(xs).head(xs)
+#define g_tail(xs) GENERIC_TRAIT_LIST(xs).tail(xs)
+#define g_drop(n, xs) GENERIC_TRAIT_LIST(xs).drop(n, xs)
+
+#define g_array(T, ...)                                                  \
+  trait(Array(T)).from_array(                                            \
+      VARIADIC_SIZE(__VA_ARGS__),                                        \
+      (T[VARIADIC_SIZE(__VA_ARGS__)]){__VA_ARGS__})
+
+#define g_list(T, ...)                                                   \
+  trait(List(T)).from_array(                                             \
+      VARIADIC_SIZE(__VA_ARGS__),                                        \
+      (T[VARIADIC_SIZE(__VA_ARGS__)]){__VA_ARGS__})

--- a/include/cparsec3/base/data.h
+++ b/include/cparsec3/base/data.h
@@ -16,7 +16,7 @@
 #define trait_Data(T)                                                    \
   C_API_BEGIN                                                            \
   /* ---- */                                                             \
-  trait_Mem(T);                                                         \
+  trait_Mem(T);                                                          \
   trait_Array(T);                                                        \
   trait_List(T);                                                         \
   /* ---- */                                                             \

--- a/include/cparsec3/base/maybe.h
+++ b/include/cparsec3/base/maybe.h
@@ -85,4 +85,4 @@
   END_OF_STATEMENTS
 
 // -----------------------------------------------------------------------
-FOREACH(trait_Maybe, TYPESET(ALL));
+// FOREACH(trait_Maybe, TYPESET(ALL));

--- a/include/cparsec3/base/mem.h
+++ b/include/cparsec3/base/mem.h
@@ -22,22 +22,24 @@
 // -----------------------------------------------------------------------
 #define impl_Mem(T)                                                      \
   C_API_BEGIN                                                            \
-  static T* FUNC_NAME(create, T)(size_t n) {                             \
+  static T* FUNC_NAME(create, Mem(T))(size_t n) {                        \
     return (T*)malloc(n * sizeof(T));                                    \
   }                                                                      \
-  static T* FUNC_NAME(recreate, T)(T * ptr, size_t n) {                  \
+  static T* FUNC_NAME(recreate, Mem(T))(T * ptr, size_t n) {             \
     return (T*)realloc(ptr, n * sizeof(T));                              \
   }                                                                      \
-  static void FUNC_NAME(free, T)(T * p) {                                \
+  static void FUNC_NAME(free, Mem(T))(T * p) {                           \
     free((void*)p);                                                      \
   }                                                                      \
   MemT(T) Trait(Mem(T)) {                                                \
-    return (MemT(T)){.create = FUNC_NAME(create, T),                     \
-                     .recreate = FUNC_NAME(recreate, T),                 \
-                     .free = FUNC_NAME(free, T)};                        \
+    return (MemT(T)){                                                    \
+        .create = FUNC_NAME(create, Mem(T)),                             \
+        .recreate = FUNC_NAME(recreate, Mem(T)),                         \
+        .free = FUNC_NAME(free, Mem(T)),                                 \
+    };                                                                   \
   }                                                                      \
   C_API_END                                                              \
   END_OF_STATEMENTS
 
 // -----------------------------------------------------------------------
-FOREACH(trait_Mem, TYPESET(ALL));
+// FOREACH(trait_Mem, TYPESET(ALL));

--- a/src/cparsec3/ParsecString.c
+++ b/src/cparsec3/ParsecString.c
@@ -2,4 +2,4 @@
 
 #include <cparsec3/ParsecString.h>
 
-CPARSEC_DEFINE_ALL(String);
+//CPARSEC_DEFINE_ALL(String);

--- a/src/cparsec3/base/base.c
+++ b/src/cparsec3/base/base.c
@@ -1,0 +1,28 @@
+/* -*- coding: utf-8-unix -*- */
+
+#include <cparsec3/base/base.h>
+
+FOREACH(impl_Mem, TYPESET(ALL));
+FOREACH(impl_Array, TYPESET(ALL));
+FOREACH(impl_List, TYPESET(ALL));
+FOREACH(impl_Maybe, TYPESET(ALL));
+
+FOREACH(impl_Mem,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(impl_Array,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(impl_List,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(impl_Maybe,
+        APPLY(Array, TYPESET(ALL)),
+        APPLY(List, TYPESET(ALL)),
+        APPLY(Maybe, TYPESET(ALL)));

--- a/src/cparsec3/base/maybe.c
+++ b/src/cparsec3/base/maybe.c
@@ -1,5 +1,0 @@
-/* -*- coding: utf-8-unix -*- */
-
-#include <cparsec3/base/base.h>
-
-FOREACH(impl_Maybe, TYPESET(ALL));

--- a/src/cparsec3/base/mem.c
+++ b/src/cparsec3/base/mem.c
@@ -1,6 +1,0 @@
-/* -*- coding: utf-8-unix -*- */
-
-#include <cparsec3/base/base.h>
-
-// -----------------------------------------------------------------------
-FOREACH(impl_Mem, TYPESET(ALL));


### PR DESCRIPTION
- added instance `Eq(Array(T))`, `Ord(Array(T))`
- added instance `Eq(List(T))`, `Ord(List(T))`
- added `from_array(n, a)` to `ArrayT(T)` and `ListT(T)` traits.
- fixed internal name of `MemT(T)` traits' member functions.
- moved declaration/definition of containers into base.{c|h}

- added `base/base_generics.h` the type-generic macros
- added example use-cases of the type-generic macros.