### PR TITLE
refactor: Itr(C), Array(T), List(T)

### DIFF
--- a/include/cparsec3/base/array.h
+++ b/include/cparsec3/base/array.h
@@ -12,31 +12,16 @@
 
 #define Array(T) TYPE_NAME(Array, T)
 #define ArrayT(T) TYPE_NAME(ArrayT, T)
-// -----------------------------------------------------------------------
-#define typedef_Array(T)                                                 \
-  C_API_BEGIN                                                            \
-  typedef struct {                                                       \
-    size_t length;                                                       \
-    T* data;                                                             \
-  } Array(T);                                                            \
-  C_API_END                                                              \
-  END_OF_STATEMENTS
 
 // -----------------------------------------------------------------------
 #define trait_Array(T)                                                   \
   C_API_BEGIN                                                            \
-  /* ---- */                                                             \
-  typedef_Array(T);                                                      \
-  /* ---- */                                                             \
-  trait_Eq(Array(T));                                                    \
-  trait_Ord(Array(T));                                                   \
-  /* ---- */                                                             \
-  typedef T Item(Array(T));                                              \
+  /* ---- Array(T) */                                                    \
   typedef struct {                                                       \
-    Array(T) a;                                                          \
-  } Itr(Array(T));                                                       \
-  trait_Itr(Array(T));                                                   \
-  /* ---- */                                                             \
+    size_t length;                                                       \
+    T* data;                                                             \
+  } Array(T);                                                            \
+  /* ---- trait Array(T) */                                              \
   typedef struct {                                                       \
     Array(T) empty;                                                      \
     bool (*null)(Array(T) a);                                            \
@@ -48,6 +33,16 @@
     T* (*end)(Array(T) a);                                               \
   } ArrayT(T);                                                           \
   ArrayT(T) Trait(Array(T));                                             \
+  /* ---- instance Eq(Array(T)) */                                       \
+  trait_Eq(Array(T));                                                    \
+  /* ---- instance Ord(Array(T)) */                                      \
+  trait_Ord(Array(T));                                                   \
+  /* ---- instance Itr(Array(T)) */                                      \
+  typedef T Item(Array(T));                                              \
+  typedef struct {                                                       \
+    Array(T) a;                                                          \
+  } Itr(Array(T));                                                       \
+  trait_Itr(Array(T));                                                   \
   /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS
@@ -128,8 +123,8 @@
   static Itr(Array(T)) FUNC_NAME(itr, Itr(Array(T)))(Array(T) a) {       \
     return (Itr(Array(T))){.a = a};                                      \
   }                                                                      \
-  static bool FUNC_NAME(null, Itr(Array(T)))(Itr(Array(T)) it) {         \
-    return !it.a.length;                                                 \
+  static T* FUNC_NAME(ptr, Itr(Array(T)))(Itr(Array(T)) it) {            \
+    return (it.a.length ? it.a.data : 0);                                \
   }                                                                      \
   static Itr(Array(T))                                                   \
       FUNC_NAME(next, Itr(Array(T)))(Itr(Array(T)) it) {                 \
@@ -140,23 +135,9 @@
     }                                                                    \
     return it;                                                           \
   }                                                                      \
-  static T FUNC_NAME(get, Itr(Array(T)))(Itr(Array(T)) it) {             \
-    assert(it.a.length&& it.a.data);                                     \
-    return it.a.data[0];                                                 \
-  }                                                                      \
-  static void FUNC_NAME(set, Itr(Array(T)))(T x, Itr(Array(T)) it) {     \
-    assert(it.a.length&& it.a.data);                                     \
-    it.a.data[0] = x;                                                    \
-  }                                                                      \
-  ItrT(Array(T)) Trait(Itr(Array(T))) {                                  \
-    return (ItrT(Array(T))){                                             \
-        .itr = FUNC_NAME(itr, Itr(Array(T))),                            \
-        .null = FUNC_NAME(null, Itr(Array(T))),                          \
-        .next = FUNC_NAME(next, Itr(Array(T))),                          \
-        .get = FUNC_NAME(get, Itr(Array(T))),                            \
-        .set = FUNC_NAME(set, Itr(Array(T))),                            \
-    };                                                                   \
-  }                                                                      \
+  instance_Itr(Array(T), FUNC_NAME(itr, Itr(Array(T))),                  \
+               FUNC_NAME(ptr, Itr(Array(T))),                            \
+               FUNC_NAME(next, Itr(Array(T))));                          \
   /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS

--- a/include/cparsec3/base/itr.h
+++ b/include/cparsec3/base/itr.h
@@ -8,16 +8,46 @@
 #define Item(C) TYPE_NAME(Item, C)
 #define Itr(C) TYPE_NAME(Itr, C)
 #define ItrT(C) TYPE_NAME(ItrT, C)
+
 // -----------------------------------------------------------------------
 #define trait_Itr(C)                                                     \
   C_API_BEGIN                                                            \
   typedef struct {                                                       \
     Itr(C) (*itr)(C c);                                                  \
-    bool (*null)(Itr(C) it);                                             \
+    Item(C) * (*ptr)(Itr(C) it);                                         \
     Itr(C) (*next)(Itr(C) it);                                           \
+    bool (*null)(Itr(C) it);                                             \
     Item(C) (*get)(Itr(C) it);                                           \
     void (*set)(Item(C) x, Itr(C) it);                                   \
   } ItrT(C);                                                             \
   ItrT(C) Trait(Itr(C));                                                 \
+  C_API_END                                                              \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define instance_Itr(C, _itr_, _ptr_, _next_)                            \
+  C_API_BEGIN                                                            \
+  static bool FUNC_NAME(null, Itr(C))(Itr(C) it) {                       \
+    return !_ptr_(it);                                                   \
+  }                                                                      \
+  static Item(C) FUNC_NAME(get, Itr(C))(Itr(C) it) {                     \
+    Item(C)* p = _ptr_(it);                                              \
+    assert(p);                                                           \
+    return *p;                                                           \
+  }                                                                      \
+  static void FUNC_NAME(set, Itr(C))(Item(C) v, Itr(C) it) {             \
+    Item(C)* p = _ptr_(it);                                              \
+    *p = v;                                                              \
+  }                                                                      \
+  ItrT(C) Trait(Itr(C)) {                                                \
+    return (ItrT(C)){                                                    \
+        .itr = _itr_,                                                    \
+        .ptr = _ptr_,                                                    \
+        .next = _next_,                                                  \
+        .null = FUNC_NAME(null, Itr(C)),                                 \
+        .get = FUNC_NAME(get, Itr(C)),                                   \
+        .set = FUNC_NAME(set, Itr(C)),                                   \
+    };                                                                   \
+  }                                                                      \
   C_API_END                                                              \
   END_OF_STATEMENTS

--- a/include/cparsec3/base/list.h
+++ b/include/cparsec3/base/list.h
@@ -15,32 +15,17 @@
 #define List(T) TYPE_NAME(List, T)
 #define stList(T) TYPE_NAME(stList, T)
 #define ListT(T) TYPE_NAME(ListT, T)
+
 // -----------------------------------------------------------------------
-#define typedef_List(T)                                                  \
+#define trait_List(T)                                                    \
   C_API_BEGIN                                                            \
+  /* ---- List(T) */                                                     \
   typedef struct stList(T) {                                             \
     struct stList(T) * tail;                                             \
     T head;                                                              \
   }                                                                      \
   stList(T), *List(T);                                                   \
-  C_API_END                                                              \
-  END_OF_STATEMENTS
-
-// -----------------------------------------------------------------------
-#define trait_List(T)                                                    \
-  C_API_BEGIN                                                            \
-  /* ---- */                                                             \
-  typedef_List(T);                                                       \
-  /* ---- */                                                             \
-  trait_Eq(List(T));                                                     \
-  trait_Ord(List(T));                                                    \
-  /* ---- */                                                             \
-  typedef T Item(List(T));                                               \
-  typedef struct {                                                       \
-    List(T) xs;                                                          \
-  } Itr(List(T));                                                        \
-  trait_Itr(List(T));                                                    \
-  /* ---- */                                                             \
+  /* ---- trait List(T) */                                               \
   typedef struct {                                                       \
     List(T) empty;                                                       \
     bool (*null)(List(T) xs);                                            \
@@ -53,6 +38,16 @@
     List(T) (*tail)(List(T) xs);                                         \
   } ListT(T);                                                            \
   ListT(T) Trait(List(T));                                               \
+  /* ---- instance Eq(List(T)) */                                        \
+  trait_Eq(List(T));                                                     \
+  /* ---- instance Ord(List(T)) */                                       \
+  trait_Ord(List(T));                                                    \
+  /* ---- instance Itr(List(T)) */                                       \
+  typedef T Item(List(T));                                               \
+  typedef struct {                                                       \
+    List(T) xs;                                                          \
+  } Itr(List(T));                                                        \
+  trait_Itr(List(T));                                                    \
   /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS
@@ -165,8 +160,8 @@
   static Itr(List(T)) FUNC_NAME(itr, Itr(List(T)))(List(T) xs) {         \
     return (Itr(List(T))){.xs = xs};                                     \
   }                                                                      \
-  static bool FUNC_NAME(null, Itr(List(T)))(Itr(List(T)) it) {           \
-    return !it.xs;                                                       \
+  static T* FUNC_NAME(ptr, Itr(List(T)))(Itr(List(T)) it) {              \
+    return (it.xs ? &(it.xs->head) : 0);                                 \
   }                                                                      \
   static Itr(List(T)) FUNC_NAME(next, Itr(List(T)))(Itr(List(T)) it) {   \
     if (it.xs) {                                                         \
@@ -174,23 +169,9 @@
     }                                                                    \
     return it;                                                           \
   }                                                                      \
-  static T FUNC_NAME(get, Itr(List(T)))(Itr(List(T)) it) {               \
-    assert(it.xs);                                                       \
-    return it.xs->head;                                                  \
-  }                                                                      \
-  static void FUNC_NAME(set, Itr(List(T)))(T x, Itr(List(T)) it) {       \
-    assert(it.xs);                                                       \
-    it.xs->head = x;                                                     \
-  }                                                                      \
-  ItrT(List(T)) Trait(Itr(List(T))) {                                    \
-    return (ItrT(List(T))){                                              \
-        .itr = FUNC_NAME(itr, Itr(List(T))),                             \
-        .null = FUNC_NAME(null, Itr(List(T))),                           \
-        .next = FUNC_NAME(next, Itr(List(T))),                           \
-        .get = FUNC_NAME(get, Itr(List(T))),                             \
-        .set = FUNC_NAME(set, Itr(List(T))),                             \
-    };                                                                   \
-  }                                                                      \
+  instance_Itr(List(T), FUNC_NAME(itr, Itr(List(T))),                    \
+               FUNC_NAME(ptr, Itr(List(T))),                             \
+               FUNC_NAME(next, Itr(List(T))));                           \
   /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS


### PR DESCRIPTION
- added `Item(C)* ItrT(C).ptr(Itr(C) it)`
- added `instance_Itr(C, _itr_, _ptr_, _next_)` macro

- refactored `trait_Array(T)` and `impl_Array(T)` macros
- removed `typedef_Array(T)` macro

- refactored `trait_List(T)` and `impl_List(T)` macros
- removed `typedef_List(T)` macro