### PR TITLE
refined document structure and fixed/added some contents.

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,6 +13,7 @@
 - *[[file:docs/concept-generics.org][Generics]]* - Generic programming for C11
   - Generic Data Types
   - Traits
+  - Generic Macros
 
 - *[[file:docs/concept-parsec.org][Parsec]]* - parsers and parser combinators
   - Stream
@@ -22,34 +23,33 @@
 
 * How to build
 
-To build and test the CPARSEC3 library, do as follows :
-- *NOTE* Suppose that the leading '*$*' is a shell prompt.
-- *NOTE* Suppose that the '*#*' follows words are comment.
-
-#+begin_src shell
-# at the project top directory
-$ ./build.sh all test
-#+end_src
-
-Or do as follows at for each directory that the GNUmakefile exists:
-#+begin_src shell
-# at the project top directory
-$ make all
-# go to the sub directory that the GNUmakefile exists
-$ cd test/testit
-# at the sub directory
-$ make all test
-#+end_src
+See [[file:docs/how_to_build.org][build-instraction]] contents for the below:
+  - How to build
+  - Disrectory structure of source tree
 
 * API references
 
-- [[file:docs/api-base.org][Base library]] :: Provides basic Generic Data Types and Traits.
+The /CPARSEC3/ library consists of the following portions:
 
-- [[file:docs/api-parsec.org][Parsec library]] :: Parser Combinator library for C11
+- [[file:docs/api-base.org][Base library]]   ::
+     /CPARSEC3/ *Base* library provides basic functionality of general purpose
+     *Generic Data Types*, *Traits*, and *Generic Macros*.
+  - Generic Data Types :
+       ~Array(T)~, ~List(T)~, ~Maybe(T)~, and so on.
+  - Traits             :
+       ~Eq(T)~, ~Ord(T)~, and so on.
+  - Generic Macros     :
+       ~g_array(T, ...)~, ~g_eq(a, b)~, ~g_itr(c)~, and so on.
+
+- [[file:docs/api-parsec.org][Parsec library]] ::
+     /CPARSEC3/ *Parsec* library provides functionality of parser-combinators.
   - Stream
   - Built-in parsers
   - Built-in parser combinators
   - Parser invocation APIs
 
-- [[file:docs/api-misc.org][Misc.]] :: Other miscellernious APIs
+- [[file:docs/api-misc.org][Misc.]]          ::
+     Other miscellernious APIs
+  - TYEPSET macro
+  - Primitive types
 

--- a/docs/api-base.org
+++ b/docs/api-base.org
@@ -13,6 +13,9 @@
 *Generic Data Type* is a similar concept as known as *parameterized type*,
 *polymorphic type*, *template class (C++)*, and so on.
 
+The below sections show *Generic Data Types* provided by /CPARSEC3/ *Base*
+library.
+
 ** Array(T) - an array of objects
 
 - Array(T)        ::
@@ -72,6 +75,8 @@
 *interface (Java)*, and so on.
 
 To use *Trait*, calling to ~trait(M)~ creates a concrete trait object.
+
+The below sections show *Traits* provided by /CPARSEC3/ *Base* library.
 
 ** Eq(T) - trait to test equality of two values
 
@@ -375,6 +380,8 @@ An ~Show(T)~ trait provides the following member functions :
      Makes it easy to use various traits and containers.
 - Cons of Generic Macros ::
      Needs much more compile time / memory.
+
+The below sections show *Generic Macros* provided by /CPARSEC3/ *Base* library.
 
 ** Tests Equality of two objects
 - g_eq(a, b)      ::

--- a/docs/api-misc.org
+++ b/docs/api-misc.org
@@ -7,34 +7,46 @@
 
 *TYPESET* macro defines a list of types.
 
-These macros are used to declare/define various *Generic Data Types* and
-*Traits* in the library implementation.
+These macros are used to declare/define various *Generic Data Types*, *Traits*,
+and *Generic Macros* in the library implementation.
 
 - TYPESET(ALL)       ::
-     ~TYPESET(PRIMITIVE)~
+     ~int~, ~TYPESET(PRIMITIVE)~
 - TYPESET(PRIMITIVE) ::
      ~None~, ~char~, ~String~, ~TYPESET(STD_INT)~
 - TYPESET(STD_INT)   ::
-     ~int~,
-     ~int8_t~, ~int16_t~, ~int32_t~, ~int64_t~
+     ~int8_t~, ~int16_t~, ~int32_t~, ~int64_t~, 
      ~uint8_t~, ~uint16_t~, ~uint32_t~, ~uint64_t~
 
 ** Primitive Types
 
-- None :: a type that represents a value of nothing.
-  - NONE :: a value of type ~None~.
-  - isNONE(x) :: macro that returns ~true~ if ~x~ was a ~None~ value.
+- None            ::
+     a type that represents a value of nothing.\\
+     ~None~ type is mainly used instead of ~void~ as return type of some parsers
+     that have no meaningful return value.
 
-- char :: a 8-bit character
+  - NONE            ::
+       a value of ~None~ type.
 
-- String :: a string. - alias of ~const char*~ (i.e. *typedef*)
+  - isNONE(x)       ::
+       macro that returns ~true~ if ~x~ was a ~None~ value.
 
-- int  :: an integer
-- int8_t :: an 8-bit integer
-- int16_t :: a 16-bit integer
-- int32_t :: a 32-bit integer
-- int64_t :: a 64-bit integer
-- uint8_t :: an 8-bit unsigned integer
+- char            ::
+     a 8-bit character
+
+- String          ::
+     a string. - type alias to ~const char*~ (i.e. *typedef*)
+
+- int             ::
+     an integer.
+  - *NOTE* : ~int~ is not a member of ~TYPESET(PRIMITIVE)~ nor ~TYPESET(STD_INT)~,
+     since it may be a type alias to other standard integer type.
+
+- int8_t   :: an 8-bit integer
+- int16_t  :: a 16-bit integer
+- int32_t  :: a 32-bit integer
+- int64_t  :: a 64-bit integer
+- uint8_t  :: an 8-bit unsigned integer
 - uint16_t :: a 16-bit unsigned integer
 - uint32_t :: a 32-bit unsigned integer
 - uint64_t :: a 64-bit unsigned integer

--- a/docs/api-parsec.org
+++ b/docs/api-parsec.org
@@ -3,30 +3,67 @@
 
 * Parsec library
 
-** Generic Data Type
+/CPARSEC3/ *Parsec* library provides functionality of parser-combinators.
+
+-----
+- *NOTE* : *Parsec* library is *UNDER CONSTRUCTION*.
+-----
+
+* Generic Data Type
+
+*Generic Data Type* is a parametric typed struct/union.
+
+*Generic Data Type* is a similar concept as known as *parameterized type*,
+*polymorphic type*, *template class (C++)*, and so on.
+
+The below sections show *Generic Data Types* provided by /CPARSEC3/ *Parsec*
+library.
+
+** Parsec(S, T) - a parser object
 
 - Parsec(S, T)     ::
-     A parser, which takes tokens from stream of type ~S~ and returns a value of
-     type ~T~ when it is applied successfully.
+     A parser object that tries to take token(s) from a stream of type ~S~ and
+     returns a corresponding value of type ~T~ when it was applied to a stream
+     successfully.\\
+     See also ~ParsecT(S, T)~ trait.
+
+** Token(S) - a token object
 
 - Token(S)         ::
-     A token, which was taken from a stream of type ~S~.
+     A token, which was taken from a stream of type ~S~.\\
+     See also ~Stream(S)~ trait.
+
+
+** Tokens(S) - a chunk of tokens
 
 - Tokens(S)        ::
-     A chunk of tokens, which was taken from a stream of type ~S~.
+     A chunk of tokens, which was taken from a stream of type ~S~.\\
+     See also ~Stream(S)~ trait.
 
-** Trait
+* Trait
 
-*** Stream(S) - trait to take tokens from a stream
+*Trait* provides a set of functions against a particular concrete type.
+
+*Trait* is a similar concept as known as *type class (Haskell)*, *trait (Rust)*,
+*interface (Java)*, and so on.
+
+To use *Trait*, calling to ~trait(M)~ creates a concrete trait object.
+
+The below sections show *Traits* provided by /CPARSEC3/ *Parsec* library.
+
+** ParsecT(S, T) - trait to construct, combinate, or apply parser
+
+- *NOTE* : Not implemented yet.
+
+** Stream(S) - trait to take tokens from a stream
 
 #+begin_src c
-  #define EQ(T) trait(Eq(T)).eq
   /* String is an instance of Stream */
   Stream(String) s = trait(Stream(String));
   Maybe(Tuple(Token(String), String)) r = s.take1("abc");
   assert(!r.none);
-  assert(EQ(char)(r.value.e1, 'a'));
-  assert(EQ(String)(r.value.e2, "bc"));
+  assert(g_eq(r.value.e1, 'a'));  /* a token */
+  assert(g_eq(r.value.e2, "bc")); /* rest of the stream */
 #+end_src
 
 - Stream(S)           ::
@@ -40,8 +77,10 @@
      type.
 
 A ~Stream(S)~ trait provides the following member functions :
+
 - bool empty(S s) ::
      Returns ~true~ if the stream ~s~ was empty, ~false~ otherwise.
+
 - Maybe(Tuple(Token(S), S)) take1(S s) ::
      Try to take a token from the stream ~s~.
   - If the stream ~s~ was empty, returns ~m~ that satisfies the following :
@@ -50,6 +89,7 @@ A ~Stream(S)~ trait provides the following member functions :
     - ~m.none~ \equal ~false~.
     - ~m.value.e1~ is the 1st token of ~Token(S)~ type.
     - ~m.value.e2~ is the *rest* of the stream ~s~.
+
 - Maybe(Tuple(Tokens(S), S)) takeN(int n, S s) ::
      Try to take a chunk of tokens from the stream ~s~.
   - If n \gt 0 and the stream ~s~ was empty, returns ~m~ that satisfies the

--- a/docs/concept-parsec.org
+++ b/docs/concept-parsec.org
@@ -3,11 +3,11 @@
 
 * TODO Parsec
 
-** Stream
+* Stream
 
-** Parser
+* Parser
 
-** Parser Combinator
+* Parser Combinator
 
-** Parser Invocation
+* Parser Invocation
 

--- a/docs/how_to_build.org
+++ b/docs/how_to_build.org
@@ -1,0 +1,58 @@
+# -*- coding: utf-8-unix -*-
+#+STARTUP: showall indent
+
+* How to build
+
+To build and test the CPARSEC3 library, do as follows :
+- *NOTE* Suppose that the leading '*$*' is a shell prompt.
+- *NOTE* Suppose that the '*#*' follows words are comment.
+
+#+begin_src shell
+# at the project top directory
+$ ./build.sh all test
+#+end_src
+
+Or do as follows at for each directory that the GNUmakefile exists:
+#+begin_src shell
+# at the project top directory
+$ make all
+# go to the sub directory that the GNUmakefile exists
+$ cd test/testit
+# at the sub directory
+$ make all test
+#+end_src
+
+* Directory strucuture of source tree
+
+The source tree of /CPARSEC3/ library consists of the contents of the /CPARSEC3/
+main project and the contents of sub-projects.
+
+- The /CPARSEC3/ main project ::
+     The /CPARSEC3/ library main project.\\
+     Placed at the top directory of the git repository.
+
+- test/testit sub project     ::
+     The /CPARSEC3/ unit-test sub project, powered by /TestIt testing
+     framework/.\\
+     Placed at the ~test/testit/~ sub directory.
+
+- example/base sub project    ::
+     The /CPARSEC3/ sample sub project, that is a usecase of the /CPARSEC3 Base
+     library/.\\
+     Placed at the ~exmaple/base/~ sub directory.
+
+-----
+
+The below shows the structure of the top directory for each main project and
+sub-projects. Note that the ~bin/~, ~lib/~, and ~obj/~ directories and its
+contents are made by ~make~ command automatically if and only if needed.
+
+*Directory structure for each main / sub project*
+- (top directory of the main / sub project)
+  - GNUmakefile :: the makefile for the project
+  - .project.mk :: the makefile for the project-specific definition
+  - include/    :: public header files
+  - src/        :: source files / private header files
+  - bin/        :: executable file
+  - lib/        :: static library / archive file (~lib*.a~)
+  - obj/        :: intermediate object files (~*.o~)


### PR DESCRIPTION
- extracted "How to build" section into `docs/how_to_build.org`.
- added "Directory structure of source tree" contents.
- fixed description of `TYPESET` macros.
- refined document structure and some contents.