### PR TITLE
fixed and sorted out `TYPESET` macros

### DIFF
--- a/include/cparsec3/base/base_generics.h
+++ b/include/cparsec3/base/base_generics.h
@@ -11,7 +11,7 @@
 // clang-format off
 #define GENERIC_EQ(x)                           \
   GENERIC(x, SND, CREATE_TRAIT,                 \
-          BIND(Eq, TYPESET(ALL_BUT_INT),        \
+          BIND(Eq, TYPESET(PRIMITIVE),          \
                APPLY_TYPESET(Array),            \
                APPLY_TYPESET(List),             \
                APPLY_TYPESET(Maybe)))
@@ -20,7 +20,7 @@
 // clang-format off
 #define GENERIC_ORD(x)                          \
   GENERIC(x, SND, CREATE_TRAIT,                 \
-          BIND(Ord, TYPESET(ALL_BUT_INT),       \
+          BIND(Ord, TYPESET(PRIMITIVE),         \
                APPLY_TYPESET(Array),            \
                APPLY_TYPESET(List),             \
                APPLY_TYPESET(Maybe)))

--- a/include/cparsec3/base/typeset.h
+++ b/include/cparsec3/base/typeset.h
@@ -9,8 +9,6 @@
 #define TYPESET_STD_INT                                                  \
   int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
 
-#define TYPESET_PRIMITIVE char, int, String, TYPESET_STD_INT
+#define TYPESET_PRIMITIVE None, char, String, TYPESET_STD_INT
 
-#define TYPESET_ALL None, TYPESET_PRIMITIVE
-
-#define TYPESET_ALL_BUT_INT None, char, String, TYPESET_STD_INT
+#define TYPESET_ALL int, TYPESET_PRIMITIVE


### PR DESCRIPTION
- modified `TYPESET(ALL)`
- modified `TYPESET(PRIMITIVE)`
- removed `TYPESET(ALL_BUT_INT)`, use `TYPESET(PRIMITIVE)` instead.

- `TYPESET(ALL)`       :
    `int` and `TYPESET(PRIMITIVE)`

- `TYPESET(PRIMITIVE)` :
    `None`, `char`, `String`, and `TYPESET(STD_INT)`