### PR TITLE
refactored some macros for faster compilation

### DIFF
--- a/include/cparsec3/base/common.h
+++ b/include/cparsec3/base/common.h
@@ -22,7 +22,10 @@
 /**
  * \brief Constructs a function-name identifier.
  */
-#define FUNC_NAME(x, ...) CAT(f_, CAT(x, CAT(_, MANGLE(__VA_ARGS__))))
+// #define FUNC_NAME(x, ...) CAT(f_, CAT(x, CAT(_, MANGLE(__VA_ARGS__))))
+#define FUNC_NAME(x, ...) FUNC_NAME1(x, MANGLE(__VA_ARGS__))
+#define FUNC_NAME1(x, y) FUNC_NAME2(x, y)
+#define FUNC_NAME2(x, y) f_##x##_##y
 
 /**
  * \brief Constructs an identifier.
@@ -33,10 +36,31 @@
  * MANGLE(A, B, C) // -> ppA_B_C
  * ~~~
  */
+/*
 #define MANGLE(...)                                                      \
   IF(IS_NIL(__VA_ARGS__))                                                \
   (HEAD(__VA_ARGS__), FOLDL(MANGLE_PAIR, __VA_ARGS__))
 #define MANGLE_PAIR(x, y) CAT(p, CAT(x, CAT(_, y)))
+*/
+#define MANGLE(...) CAT(MANGLE, VARIADIC_SIZE(__VA_ARGS__))(__VA_ARGS__)
+// clang-format off
+#define MANGLE1(_1)                                                      \
+  _1
+#define MANGLE2(_1, _2)                                                  \
+  p##_1##_##_2
+#define MANGLE3(_1, _2, _3)                                              \
+  pp##_1##_##_2##_##_3
+#define MANGLE4(_1, _2, _3, _4)                                          \
+  ppp##_1##_##_2##_##_3##_##_4
+#define MANGLE5(_1, _2, _3, _4, _5)                                      \
+  pppp##_1##_##_2##_##_3##_##_4##_##_5
+#define MANGLE6(_1, _2, _3, _4, _5, _6)                                  \
+  ppppp##_1##_##_2##_##_3##_##_4##_##_5##_##_6
+#define MANGLE7(_1, _2, _3, _4, _5, _6, _7)                              \
+  pppppp##_1##_##_2##_##_3##_##_4##_##_5##_##_6##_##_7
+#define MANGLE8(_1, _2, _3, _4, _5, _6, _7, _8)                          \
+  ppppppp##_1##_##_2##_##_3##_##_4##_##_5##_##_6##_##_7##_##_8
+// clang-format on
 
 /**
  * \brief F(T); ... for each T in variadic arguments.

--- a/include/cparsec3/base/typeset.h
+++ b/include/cparsec3/base/typeset.h
@@ -4,7 +4,8 @@
 #include "common.h"
 #include "none.h"
 
-#define TYPESET(C) SQUASH(CAT(TYPESET_, C))
+// #define TYPESET(C) SQUASH(CAT(TYPESET_, C))
+#define TYPESET(C) TYPESET_##C
 
 #define TYPESET_STD_INT                                                  \
   int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t


### PR DESCRIPTION
To improve compilation time/memory consumption, refactored the following macros:
- `FUNC_NAME(x, ...)`
- `MANGLE(...)`
- `TYPESET(C)`
