### PR TITLE
Refactor/tie

### DIFF
--- a/include/cparsec3/base/base_generics.h
+++ b/include/cparsec3/base/base_generics.h
@@ -118,4 +118,26 @@
   assert(step && "g_for(it, c, step): step == 0 not permitted.");        \
   for (__auto_type it = g_itr(c); !g_null(it); it = g_skip(step, it))
 
+#define g_bind(x, t) g_bind_I(t, DISCLOSE(x))
+#define g_bind_I(t, ...)                                                 \
+  FOREACH(EXPAND, SQUASH(APPLY(g_bind0, (TMPID, t),                      \
+                               CAT(g_bind, VARIADIC_SIZE(__VA_ARGS__))(  \
+                                   TMPID, __VA_ARGS__))))
+#define g_bind0(var_, val_) IF(IS_NULL(var_))(, __auto_type var_ = val_)
+// clang-format off
+#define g_bind1(t, _1)                                                   \
+  (_1, t.e1)
+#define g_bind2(t, _1, _2)                                               \
+  (_1, t.e1), (_2, t.e2)
+#define g_bind3(t, _1, _2, _3)                                           \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3)
+#define g_bind4(t, _1, _2, _3, _4)                                       \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3), (_4, t.e4)
+#define g_bind5(t, _1, _2, _3, _4, _5)                                   \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3), (_4, t.e4), (_5, t.e5)
+#define g_bind6(t, _1, _2, _3, _4, _5, _6)                               \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3), (_4, t.e4), (_5, t.e5), (_6, t.e6)
+// clang-format on
+
+#define TMPID CAT(tmpid__, __LINE__)
 #endif

--- a/include/cparsec3/base/tuple.h
+++ b/include/cparsec3/base/tuple.h
@@ -129,37 +129,21 @@
  */
 #define tie(x, t) tie_I(t, DISCLOSE(x))
 #define tie_I(t, ...)                                                    \
-  CAT(tie, VARIADIC_SIZE(__VA_ARGS__))                                   \
-  (t, __VA_ARGS__)
+  FOREACH(EXPAND,                                                        \
+          SQUASH(APPLY(tie0, CAT(tie, VARIADIC_SIZE(__VA_ARGS__))(       \
+                                 t, __VA_ARGS__))))
+#define tie0(var_, val_) IF(IS_NULL(var_))(, var_ = val_)
 // clang-format off
-#define tie1(t, _1)                             \
-  tie0((_1, _1 = t.e1))
-#define tie2(t, _1, _2)                         \
-  tie0((_1, _1 = t.e1),                         \
-       (_2, _2 = t.e2))
-#define tie3(t, _1, _2, _3)                     \
-  tie0((_1, _1 = t.e1),                         \
-       (_2, _2 = t.e2),                         \
-       (_3, _3 = t.e3))
-#define tie4(t, _1, _2, _3, _4)                 \
-  tie0((_1, _1 = t.e1),                         \
-       (_2, _2 = t.e2),                         \
-       (_3, _3 = t.e3),                         \
-       (_4, _4 = t.e4))
-#define tie5(t, _1, _2, _3, _4, _5)             \
-  tie0((_1, _1 = t.e1),                         \
-       (_2, _2 = t.e2),                         \
-       (_3, _3 = t.e3),                         \
-       (_4, _4 = t.e4),                         \
-       (_5, _5 = t.e5))
-#define tie6(t, _1, _2, _3, _4, _5, _6)         \
-  tie0((_1, _1 = t.e1),                         \
-       (_2, _2 = t.e2),                         \
-       (_3, _3 = t.e3),                         \
-       (_4, _4 = t.e4),                         \
-       (_5, _5 = t.e5),                         \
-       (_6, _6 = t.e6))
+#define tie1(t, _1)                                                      \
+  (_1, t.e1)
+#define tie2(t, _1, _2)                                                  \
+  (_1, t.e1), (_2, t.e2)
+#define tie3(t, _1, _2, _3)                                              \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3)
+#define tie4(t, _1, _2, _3, _4)                                          \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3), (_4, t.e4)
+#define tie5(t, _1, _2, _3, _4, _5)                                      \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3), (_4, t.e4), (_5, t.e5)
+#define tie6(t, _1, _2, _3, _4, _5, _6)                                  \
+  (_1, t.e1), (_2, t.e2), (_3, t.e3), (_4, t.e4), (_5, t.e5), (_6, t.e6)
 // clang-format on
-#define tie0(...) FOREACH(tie0_id, SQUASH(APPLY(tie0_f, __VA_ARGS__)))
-#define tie0_f(x, y) IF(IS_NULL(x))(, y)
-#define tie0_id(x) x


### PR DESCRIPTION
- refactored `tie((a,b,...), tuple)` macro (defined in `tuple.h`)
- added `g_bind((a,b,...), tuple)` generic macro, using `__auto_type` GCC extension.