### PR TITLE
fixed: `parseTest`'s 2nd parameter `name` is useless.

### DIFF
--- a/example/parsec/src/parsec.c
+++ b/example/parsec/src/parsec.c
@@ -37,22 +37,22 @@ int main(void) {
   __auto_type D = trait(ParsecDeriv(S));
 
   __auto_type p1 = P.parseError((ParseError(S)){0});
-  R.parseTest(p1, "", "");
-  R.parseTest(p1, "", "foo");
-  R.parseTest(p1, "", "bar");
+  R.parseTest(p1, "");
+  R.parseTest(p1, "foo");
+  R.parseTest(p1, "bar");
 
   __auto_type p2 = D.single('f');
-  R.parseTest(p2, "", "");
-  R.parseTest(p2, "", "foo");
-  R.parseTest(p2, "", "bar");
+  R.parseTest(p2, "");
+  R.parseTest(p2, "foo");
+  R.parseTest(p2, "bar");
 
   __auto_type p3 = D.anySingle();
-  R.parseTest(p3, "", "");
-  R.parseTest(p3, "", "foo");
-  R.parseTest(p3, "", "bar");
+  R.parseTest(p3, "");
+  R.parseTest(p3, "foo");
+  R.parseTest(p3, "bar");
 
   __auto_type p4 = D.anySingleBut('f');
-  R.parseTest(p4, "", "");
-  R.parseTest(p4, "", "foo");
-  R.parseTest(p4, "", "bar");
+  R.parseTest(p4, "");
+  R.parseTest(p4, "foo");
+  R.parseTest(p4, "bar");
 }

--- a/include/cparsec3/parsec/ParsecRunner.h
+++ b/include/cparsec3/parsec/ParsecRunner.h
@@ -15,7 +15,7 @@
     ParseReply(S, T) (*runParsec)(Parsec(S, T) p, ParseState(S) state);  \
     Result(T, ParseError(S)) (*runParser)(Parsec(S, T) p, String name,   \
                                           S input);                      \
-    bool (*parseTest)(Parsec(S, T) p, String name, S input);             \
+    bool (*parseTest)(Parsec(S, T) p, S input);                          \
   };                                                                     \
   ParsecRunner(S, T) Trait(ParsecRunner(S, T));                          \
   /* ---- */                                                             \
@@ -92,10 +92,9 @@
 
 // -----------------------------------------------------------------------
 #define impl_parseTest(S, T)                                             \
-  /* ---- parseTest(p, name, input) */                                   \
-  static bool FUNC_NAME(parseTest, S, T)(Parsec(S, T) p, String name,    \
-                                         S input) {                      \
-    __auto_type result = FUNC_NAME(runParser, S, T)(p, name, input);     \
+  /* ---- parseTest(p, input) */                                         \
+  static bool FUNC_NAME(parseTest, S, T)(Parsec(S, T) p, S input) {      \
+    __auto_type result = FUNC_NAME(runParser, S, T)(p, "", input);       \
     if (!result.success) {                                               \
       printf("error: ...\n");                                            \
       return false;                                                      \


### PR DESCRIPTION
removed `name` parameter.