### PR TITLE
added "memory allocation context" feature

### DIFF
--- a/include/cparsec3/base/internal/function.h
+++ b/include/cparsec3/base/internal/function.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../mem.h"
 
 // -----------------------------------------------------------------------
 #undef Fn
@@ -186,7 +187,7 @@
   /* ---- */                                                             \
   static Fn(T1, R) name(void) {                                          \
     return (Fn(T1, R)){                                                  \
-        .args = malloc(sizeof(FnEnv(name, T1))),                         \
+        .args = mem_malloc(sizeof(FnEnv(name, T1))),                     \
         .apply = FUNC_NAME(name, apply1),                                \
     };                                                                   \
   }                                                                      \
@@ -213,7 +214,7 @@
   /* ---- */                                                             \
   static Fn(T2, T1, R) name(void) {                                      \
     return (Fn(T2, T1, R)){                                              \
-        .args = malloc(sizeof(FnEnv(name, T2, T1))),                     \
+        .args = mem_malloc(sizeof(FnEnv(name, T2, T1))),                 \
         .apply = FUNC_NAME(name, apply2),                                \
     };                                                                   \
   }                                                                      \
@@ -249,7 +250,7 @@
   /* ---- */                                                             \
   static Fn(T3, T2, T1, R) name(void) {                                  \
     return (Fn(T3, T2, T1, R)){                                          \
-        .args = malloc(sizeof(FnEnv(name, T3, T2, T1))),                 \
+        .args = mem_malloc(sizeof(FnEnv(name, T3, T2, T1))),             \
         .apply = FUNC_NAME(name, apply3),                                \
     };                                                                   \
   }                                                                      \
@@ -294,7 +295,7 @@
   /* ---- */                                                             \
   static Fn(T4, T3, T2, T1, R) name(void) {                              \
     return (Fn(T4, T3, T2, T1, R)){                                      \
-        .args = malloc(sizeof(FnEnv(name, T4, T3, T2, T1))),             \
+        .args = mem_malloc(sizeof(FnEnv(name, T4, T3, T2, T1))),         \
         .apply = FUNC_NAME(name, apply4),                                \
     };                                                                   \
   }                                                                      \
@@ -350,7 +351,7 @@
   /* ---- */                                                             \
   static Fn(T5, T4, T3, T2, T1, R) name(void) {                          \
     return (Fn(T5, T4, T3, T2, T1, R)){                                  \
-        .args = malloc(sizeof(FnEnv(name, T5, T4, T3, T2, T1))),         \
+        .args = mem_malloc(sizeof(FnEnv(name, T5, T4, T3, T2, T1))),     \
         .apply = FUNC_NAME(name, apply5),                                \
     };                                                                   \
   }                                                                      \
@@ -417,7 +418,7 @@
   /* ---- */                                                             \
   static Fn(T6, T5, T4, T3, T2, T1, R) name(void) {                      \
     return (Fn(T6, T5, T4, T3, T2, T1, R)){                              \
-        .args = malloc(sizeof(FnEnv(name, T6, T5, T4, T3, T2, T1))),     \
+        .args = mem_malloc(sizeof(FnEnv(name, T6, T5, T4, T3, T2, T1))), \
         .apply = FUNC_NAME(name, apply6),                                \
     };                                                                   \
   }                                                                      \
@@ -496,7 +497,8 @@
   /* ---- */                                                             \
   static Fn(T7, T6, T5, T4, T3, T2, T1, R) name(void) {                  \
     return (Fn(T7, T6, T5, T4, T3, T2, T1, R)){                          \
-        .args = malloc(sizeof(FnEnv(name, T7, T6, T5, T4, T3, T2, T1))), \
+        .args =                                                          \
+            mem_malloc(sizeof(FnEnv(name, T7, T6, T5, T4, T3, T2, T1))), \
         .apply = FUNC_NAME(name, apply7),                                \
     };                                                                   \
   }                                                                      \
@@ -586,8 +588,8 @@
   /* ---- */                                                             \
   static Fn(T8, T7, T6, T5, T4, T3, T2, T1, R) name(void) {              \
     return (Fn(T8, T7, T6, T5, T4, T3, T2, T1, R)){                      \
-        .args =                                                          \
-            malloc(sizeof(FnEnv(name, T8, T7, T6, T5, T4, T3, T2, T1))), \
+        .args = mem_malloc(                                              \
+            sizeof(FnEnv(name, T8, T7, T6, T5, T4, T3, T2, T1))),        \
         .apply = FUNC_NAME(name, apply8),                                \
     };                                                                   \
   }                                                                      \
@@ -688,7 +690,7 @@
   /* ---- */                                                             \
   static Fn(T9, T8, T7, T6, T5, T4, T3, T2, T1, R) name(void) {          \
     return (Fn(T9, T8, T7, T6, T5, T4, T3, T2, T1, R)){                  \
-        .args = malloc(                                                  \
+        .args = mem_malloc(                                              \
             sizeof(FnEnv(name, T9, T8, T7, T6, T5, T4, T3, T2, T1))),    \
         .apply = FUNC_NAME(name, apply9),                                \
     };                                                                   \

--- a/include/cparsec3/base/mem.h
+++ b/include/cparsec3/base/mem.h
@@ -23,13 +23,13 @@
 #define impl_Mem(T)                                                      \
   C_API_BEGIN                                                            \
   static T* FUNC_NAME(create, Mem(T))(size_t n) {                        \
-    return (T*)malloc(n * sizeof(T));                                    \
+    return (T*)mem_malloc(n * sizeof(T));                                \
   }                                                                      \
   static T* FUNC_NAME(recreate, Mem(T))(T * ptr, size_t n) {             \
-    return (T*)realloc(ptr, n * sizeof(T));                              \
+    return (T*)mem_realloc(ptr, n * sizeof(T));                          \
   }                                                                      \
   static void FUNC_NAME(free, Mem(T))(T * p) {                           \
-    free((void*)p);                                                      \
+    mem_free((void*)p);                                                  \
   }                                                                      \
   MemT(T) Trait(Mem(T)) {                                                \
     return (MemT(T)){                                                    \
@@ -40,3 +40,76 @@
   }                                                                      \
   C_API_END                                                              \
   END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+C_API_BEGIN
+
+/**
+ * \brief Type of the "memory allocation context" handle.
+ */
+typedef struct MemCtx* MemCtx;
+
+/**
+ * \brief Establishes new memory allocation context.
+ *
+ * mem_ctx_begin() does following:
+ * 1. creates a new memory allocation context,
+ * 2. registers it as the child of the current context,
+ * 3. establiches it as the current context. and then
+ * 4. returns the new established context.
+ *
+ * \return the handle of the new memory allocation context.
+ */
+MemCtx mem_ctx_begin(void);
+/**
+ * \brief Releases and rollbacks the memory allocation context.
+ *
+ * mem_ctx_end() does following:
+ * 1. releases the given memory allocation context `ctx`,
+ * 2. releases all memory blocks which were associated to `ctx`,
+ * 3. releases all children of the given context recursively,
+ * 4. releases all memory blocks which were associated to the children,
+ * 5. rollbacks to the given context's parent as the current context.
+ *
+ * \param ctx   the handle of the memory allocation context.
+ */
+void mem_ctx_end(MemCtx ctx);
+
+// -----------------------------------------------------------------------
+/**
+ * \brief Allocates new memory block associated to the current memory
+ * allocation context.
+ *
+ * \param sz   size of the memory block in bytes.
+ * \return     the allocated memory block, or NULL if failed.
+ *
+ * \note if no memory allocation context was established before, a new
+ * context was established as the current context at first.
+ */
+void* mem_malloc(size_t sz);
+/**
+ * \brief Reallocates the memory block which is previously allocated by
+ * mem_malloc() or mem_realloc().
+ *
+ * \param p    pointer to the memory block which is previously allocated.
+ * \param sz   new size of the memory block in bytes.
+ * \return     the reallocated memory block, or NULL if not reallocated.
+ *
+ * \note if no memory allocation context was established before, a new
+ * context was established as the current context at first.
+ */
+void* mem_realloc(void* p, size_t sz);
+/**
+ * \brief Releases the memory block which is previously allocated by
+ * mem_malloc() or mem_realloc().
+ *
+ * \param p    pointer to the memory block which is previously allocated.
+ */
+void mem_free(void* p);
+
+// -----------------------------------------------------------------------
+#include <stdarg.h>
+int mem_asprintf(char** strp, const char* fmt, ...);
+int mem_vasprintf(char** strp, const char* fmt, va_list ap);
+
+C_API_END

--- a/src/cparsec3/base/mem.c
+++ b/src/cparsec3/base/mem.c
@@ -1,0 +1,211 @@
+/* -*- coding: utf-8-unix -*- */
+
+#include <cparsec3/base/base.h>
+
+// -----------------------------------------------------------------------
+struct MemCtx {
+  size_t capacity;
+  size_t length;
+  void** data;
+  MemCtx parent;
+};
+
+static MemCtx current_ctx = 0;
+
+static inline MemCtx mem_ctx_new(void) {
+  MemCtx ctx = malloc(sizeof(struct MemCtx));
+  assert(ctx && "failed to establish new memory allocation context");
+  *ctx = (struct MemCtx){0};
+  return ctx;
+}
+
+static inline void mem_ctx_free(MemCtx ctx) {
+  if (ctx->data) {
+    size_t n = ctx->length;
+    while (n) {
+      free(ctx->data[--n]);
+    }
+    free(ctx->data);
+  }
+  *ctx = (struct MemCtx){0};
+  free(ctx);
+}
+
+static inline void mem_ctx_push(void) {
+  MemCtx ctx = mem_ctx_new();
+  ctx->parent = current_ctx;
+  current_ctx = ctx;
+}
+
+static inline void mem_ctx_pop(void) {
+  if (!current_ctx) {
+    return;
+  }
+  MemCtx ctx = current_ctx;
+  current_ctx = ctx->parent;
+  mem_ctx_free(ctx);
+}
+
+#if defined(__GNUC__)
+__attribute__((destructor)) static inline void mem_ctx_free_all(void) {
+  while (current_ctx) {
+    mem_ctx_pop();
+  }
+}
+#endif
+
+// -----------------------------------------------------------------------
+MemCtx mem_ctx_begin(void) {
+  mem_ctx_push();
+  return current_ctx;
+}
+
+void mem_ctx_end(MemCtx ctx) {
+  assert(ctx && "Null frame pointer");
+  MemCtx parent = ctx->parent;
+  while (current_ctx && parent != current_ctx) {
+    mem_ctx_pop();
+  }
+}
+
+// for RAII
+void FUNC_NAME(free, MemCtx)(MemCtx* p) {
+  assert(p && "Null pointer");
+  mem_ctx_end(*p);
+  *p = NULL;
+}
+
+// -----------------------------------------------------------------------
+static inline MemCtx mem_ctx_current(void) {
+  if (!current_ctx) {
+    mem_ctx_push();
+  }
+  return current_ctx;
+}
+
+#define MEM_CTX_EXPAND_SLOTS (64)
+static inline void mem_ctx_ensure(MemCtx ctx) {
+  if (!ctx->data) {
+    size_t cap = MEM_CTX_EXPAND_SLOTS;
+    void* p = malloc(sizeof(void*) * cap);
+    assert(p && "No memory");
+    ctx->capacity = cap;
+    ctx->length = 0;
+    ctx->data = p;
+    return;
+  }
+  if (ctx->length == ctx->capacity) {
+    size_t cap = ctx->length + MEM_CTX_EXPAND_SLOTS;
+    void* p = realloc(ctx->data, sizeof(void*) * cap);
+    assert(p && "No memory");
+    ctx->capacity = cap;
+    ctx->data = p;
+  }
+}
+
+static inline void* on_malloc(void* p, MemCtx ctx) {
+  if (!p) {
+    return NULL;
+  }
+  // add entry
+  mem_ctx_ensure(ctx);
+  ctx->data[ctx->length++] = p;
+  return p;
+}
+
+static inline void* on_realloc(void* oldptr, void* newptr, MemCtx ctx) {
+  if (!newptr) {
+    return NULL;
+  }
+  // replace entry
+  if (!oldptr) {
+    return on_malloc(newptr, ctx);
+  }
+  for (MemCtx c = ctx; c; c = c->parent) {
+    size_t n = c->length;
+    while (n) {
+      n--;
+      if (c->data[n] == oldptr) {
+        c->data[n] = newptr;
+        return newptr;
+      }
+    }
+  }
+  // not found
+  return on_malloc(newptr, ctx);
+}
+
+static inline void on_free(void* p, MemCtx ctx) {
+  if (!p) {
+    return;
+  }
+  // remove entry
+  for (MemCtx c = ctx; c; c = c->parent) {
+    size_t n = c->length;
+    while (n) {
+      n--;
+      if (c->data[n] == p) {
+        c->length--;
+        c->data[n] = c->data[c->length];
+        return;
+      }
+    }
+  }
+  // not found
+}
+
+// -----------------------------------------------------------------------
+void* mem_malloc(size_t sz) {
+  return on_malloc(malloc(sz), mem_ctx_current());
+}
+
+void* mem_realloc(void* p, size_t sz) {
+  return on_realloc(p, realloc(p, sz), mem_ctx_current());
+}
+
+void mem_free(void* p) {
+  free(p);
+  on_free(p, mem_ctx_current());
+}
+
+// -----------------------------------------------------------------------
+int mem_asprintf(char** strp, const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int ret = mem_vasprintf(strp, fmt, ap);
+  va_end(ap);
+  return ret;
+}
+
+int mem_vasprintf(char** strp, const char* fmt, va_list ap) {
+  assert(strp && "Null pointer");
+  assert(fmt && "Null pointer");
+
+  va_list ap2;
+
+  va_copy(ap2, ap);
+  int len = vsnprintf(NULL, 0, fmt, ap2);
+  va_end(ap2);
+  if (len < 0) {
+    *strp = NULL;
+    return -1;
+  }
+
+  char* buf = mem_malloc(len + 1);
+  if (!buf) {
+    *strp = NULL;
+    return -1;
+  }
+
+  va_copy(ap2, ap);
+  int l = vsnprintf(buf, len + 1, fmt, ap2);
+  va_end(ap2);
+  if (l != len) {
+    mem_free(buf);
+    *strp = NULL;
+    return -1;
+  }
+
+  *strp = buf;
+  return len;
+}


### PR DESCRIPTION
- scoped memory allocation (stack-frame like memory allocation management)
~~~c
MemCtx a = mem_ctx_begin(); // (1)
void* p1 = mem_malloc(10);
void* p2 = mem_malloc(5);
...
mem_ctx_end(a); // de-allocates all memory allocated by mem_malloc() after (1)
~~~

- RAII scoped memory allocation (GCC only)
~~~c
{
  g_scoped(MemCtx) a = mem_ctx_begin(); // (2)
  void* p1 = mem_malloc(10);
  void* p2 = mem_malloc(5);
  ...
} // all memory allocated by mem_malloc() after (2) are de-allocated automatically.
~~~

- automatic de-allocation of all allocated memory on exit (GCC only)
~~~c
int main(void) {
  void* p1 = mem_malloc(10);
  void* p2 = mem_malloc(5);
  ...
} // all memory allocated by mem_malloc() are de-allocated automatically.
~~~
