### PR TITLE
refactored Stream(S) and implementation of Stream(String)

### DIFF
--- a/include/cparsec3/parsec/stream.h
+++ b/include/cparsec3/parsec/stream.h
@@ -17,7 +17,9 @@
   /* ---- */                                                             \
   typedef struct Stream(S) Stream(S);                                    \
   struct Stream(S) {                                                     \
-    bool (*empty)(S s);                                                  \
+    bool (*null)(S s);                                                   \
+    List(Token(S)) (*chunkToTokens)(Tokens(S) chk);                      \
+    int (*chunkLength)(Tokens(S) chk);                                   \
     Maybe(Tuple(Token(S), S)) (*take1)(S s);                             \
     Maybe(Tuple(Tokens(S), S)) (*takeN)(int n, S s);                     \
   };                                                                     \

--- a/include/cparsec3/stream/stream_string.h
+++ b/include/cparsec3/stream/stream_string.h
@@ -7,14 +7,14 @@
  * |-----------+----------------+-----------------------------|
  * | S         | String         | a stream type               |
  * | Token(S)  | Token(String)  | char                        |
- * | Tokens(S) | Tokens(String) | type of a chunk of `char`s. |
+ * | Tokens(S) | Tokens(String) | String                      |
  * |-----------+----------------+-----------------------------|
  * | Stream(S) | Stream(String) | a set of stream I/F         |
  *
  * Calling to `trait(Stream(String))` returns a Stream(String).
  *
  * A Stream(String) object is a struct contains the following functions:
- *   - empty(String)
+ *   - null(String)
  *   - take1(String)
  *   - takeN(int, String)
  *
@@ -27,25 +27,13 @@ C_API_BEGIN
 // -------------------------------------------------------------
 
 /** Token(S) : A data element taken from stream of type S */
-typedef char Token(String);
+#define pToken_String char
 
 /** Tokens(S) : A chunk of data elements taken from stream of type S */
-typedef struct Tokens(String) Tokens(String);
-struct Tokens(String) {
-  size_t length;
-  const char* value;
-};
+#define pTokens_String String
 
 /** S : A stream */
 trait_Stream(String);
-
-trait_Eq(Token(String));
-trait_Ord(Token(String));
-trait_Show(Token(String));
-trait_Maybe(Token(String));
-typedef Token(String) Item(List(Token(String)));
-trait_List(Token(String));
-trait_Array(Token(String));
 
 // -------------------------------------------------------------
 C_API_END

--- a/src/cparsec3/stream/stream_string.c
+++ b/src/cparsec3/stream/stream_string.c
@@ -14,14 +14,16 @@ static bool null(String s) {
   return !s[0];
 }
 
-static List(Token(String)) chunkToTokens(Tokens(String) chk) {
-  assert(chk && "Null pointer");
-  return trait(List(Token(String))).from_array(strlen(chk), (char*)chk);
-}
-
 static int chunkLength(Tokens(String) chk) {
   assert(chk && "Null pointer");
-  return strlen(chk);
+  size_t n = strnlen(chk, SIZE_MAX / 2);
+  return (int)n;
+}
+
+static List(Token(String)) chunkToTokens(Tokens(String) chk) {
+  assert(chk && "Null pointer");
+  return trait(List(Token(String)))
+      .from_array(chunkLength(chk), (char*)chk);
 }
 
 /**
@@ -74,7 +76,9 @@ static Maybe(Tuple(Tokens(String), String)) takeN(int n, String s) {
     int m = strnlen(s, n);
     char* chk = mem_malloc(m + 1);
     assert(chk && "no memory");
-    strncpy(chk, s, m);
+    if (0 < m) {
+      memcpy(chk, s, m);
+    }
     chk[m] = '\0';
     return (R){.value = {{chk}, {s + m}}};
   }

--- a/src/cparsec3/stream/stream_string.c
+++ b/src/cparsec3/stream/stream_string.c
@@ -4,68 +4,24 @@
 
 #include <string.h>
 
-Eq(Token(String)) Trait(Eq(Token(String))) {
-  Eq(char) t = trait(Eq(char));
-  return *(Eq(Token(String))*)&t;
-}
-
-Ord(Token(String)) Trait(Ord(Token(String))) {
-  Ord(char) t = trait(Ord(char));
-  return *(Ord(Token(String))*)&t;
-}
-
-Show(Token(String)) Trait(Show(Token(String))) {
-  Show(char) t = trait(Show(char));
-  return *(Show(Token(String))*)&t;
-}
-
-ListT(Token(String)) Trait(List(Token(String))) {
-  ListT(char) t = trait(List(char));
-  return *(ListT(Token(String))*)&t;
-}
-
-Eq(List(Token(String))) Trait(Eq(List(Token(String)))) {
-  Eq(List(char)) t = trait(Eq(List(char)));
-  return *(Eq(List(Token(String))*))&t;
-}
-
-Ord(List(Token(String))) Trait(Ord(List(Token(String)))) {
-  Ord(List(char)) t = trait(Ord(List(char)));
-  return *(Ord(List(Token(String))*))&t;
-}
-
-Iterable(List(Token(String))) Trait(Iterable(List(Token(String)))) {
-  Iterable(List(char)) t = trait(Iterable(List(char)));
-  return *(Iterable(List(Token(String)))*)&t;
-}
-
-ItrT(List(Token(String))) Trait(Itr(List(Token(String)))) {
-  ItrT(List(char)) t = trait(Itr(List(char)));
-  return *(ItrT(List(Token(String)))*)&t;
-}
-
-ArrayT(Token(String)) Trait(Array(Token(String))) {
-  ArrayT(char) t = trait(Array(char));
-  return *(ArrayT(Token(String))*)&t;
-}
-
-Iterable(Array(Token(String))) Trait(Iterable(Array(Token(String)))) {
-  Iterable(Array(char)) t = trait(Iterable(Array(char)));
-  return *(Iterable(Array(Token(String)))*)&t;
-}
-
-ItrT(Array(Token(String))) Trait(Itr(Array(Token(String)))) {
-  ItrT(Array(char)) t = trait(Itr(Array(char)));
-  return *(ItrT(Array(Token(String)))*)&t;
-}
-
 /**
  * Tests whether the stream was empty or not.
  * \param s    a stream
  * \return     true if s was empty, false otherwise.
  */
-static bool empty(String s) {
+static bool null(String s) {
+  assert(s && "Null pointer");
   return !s[0];
+}
+
+static List(Token(String)) chunkToTokens(Tokens(String) chk) {
+  assert(chk && "Null pointer");
+  return trait(List(Token(String))).from_array(strlen(chk), (char*)chk);
+}
+
+static int chunkLength(Tokens(String) chk) {
+  assert(chk && "Null pointer");
+  return strlen(chk);
 }
 
 /**
@@ -81,8 +37,9 @@ static bool empty(String s) {
  *            - nothing (if `s` was empty)
  */
 static Maybe(Tuple(Token(String), String)) take1(String s) {
+  assert(s && "Null pointer");
   typedef Maybe(Tuple(Token(String), String)) R;
-  if (empty(s)) {
+  if (null(s)) {
     return (R){.none = true};
   } else {
     return (R){.value = {{s[0]}, {s + 1}}};
@@ -106,17 +63,20 @@ static Maybe(Tuple(Token(String), String)) take1(String s) {
  *            - nothing (if `n > 0` and `s` was empty)
  */
 static Maybe(Tuple(Tokens(String), String)) takeN(int n, String s) {
+  assert(s && "Null pointer");
   typedef Maybe(Tuple(Tokens(String), String)) R;
   if (n <= 0) {
-    Tokens(String) x = {.length = 0, .value = ""};
-    return (R){.value = {{x}, {s}}};
+    return (R){.value = {{""}, {s}}};
   }
-  if (empty(s)) {
+  if (null(s)) {
     return (R){.none = true};
   } else {
     int m = strnlen(s, n);
-    Tokens(String) x = {.length = m, .value = s};
-    return (R){.value = {{x}, {s + m}}};
+    char* chk = mem_malloc(m + 1);
+    assert(chk && "no memory");
+    strncpy(chk, s, m);
+    chk[m] = '\0';
+    return (R){.value = {{chk}, {s + m}}};
   }
 }
 
@@ -124,5 +84,11 @@ static Maybe(Tuple(Tokens(String), String)) takeN(int n, String s) {
  * Returns a set of Stream API functions.
  */
 Stream(String) Trait(Stream(String)) {
-  return (Stream(String)){.empty = empty, .take1 = take1, .takeN = takeN};
+  return (Stream(String)){
+      .null = null,
+      .chunkToTokens = chunkToTokens,
+      .chunkLength = chunkLength,
+      .take1 = take1,
+      .takeN = takeN,
+  };
 }

--- a/test/testit/src/cparsec3/stream/test_stream_string_takeN.c
+++ b/test/testit/src/cparsec3/stream/test_stream_string_takeN.c
@@ -6,12 +6,8 @@
 
 #define Nothing                                                          \
   { .none = true }
-#define Just(len, toks, rest)                                            \
-  {                                                                      \
-    .value.first = {.length = (len), .value = (toks)},                   \
-    .value.second = (rest)                                               \
-  }
-#define may_follos_something ".."
+#define Just(toks, rest)                                                 \
+  { .value.first = (toks), .value.second = (rest) }
 
 struct data {
   int n; /* max length of chunk */
@@ -21,16 +17,16 @@ struct data {
 
 static void* T_GENERATOR(size_t i) {
   static struct data ret[] = {
-      {-1, "", Just(0, "" may_follos_something, "")},
-      {+0, "", Just(0, "" may_follos_something, "")},
+      {-1, "", Just("", "")},
+      {+0, "", Just("", "")},
       {+1, "", Nothing},
 
-      {-1, "abc", Just(0, "" may_follos_something, "abc")},
-      {+0, "abc", Just(0, "" may_follos_something, "abc")},
-      {+1, "abc", Just(1, "a" may_follos_something, "bc")},
-      {+2, "abc", Just(2, "ab" may_follos_something, "c")},
-      {+3, "abc", Just(3, "abc" may_follos_something, "")},
-      {+4, "abc", Just(3, "abc" may_follos_something, "")},
+      {-1, "abc", Just("", "abc")},
+      {+0, "abc", Just("", "abc")},
+      {+1, "abc", Just("a", "bc")},
+      {+2, "abc", Just("ab", "c")},
+      {+3, "abc", Just("abc", "")},
+      {+4, "abc", Just("abc", "")},
   };
   if (i < sizeof(ret) / sizeof(ret[0])) {
     return &(ret[i]);
@@ -40,6 +36,5 @@ static void* T_GENERATOR(size_t i) {
 
 #undef Nothing
 #undef Just
-#undef may_follos_something
 
 #include "./test_stream_takeN.h"

--- a/test/testit/src/cparsec3/stream/test_stream_take1.h
+++ b/test/testit/src/cparsec3/stream/test_stream_take1.h
@@ -22,12 +22,12 @@ static inline bool tok_eq(Tok a, Tok b) {
   return eq(a_token, b_token) && eq(a_rest, b_rest);
 }
 
-test("if !empty(input) := true, then "
+test("if !null(input) := true, then "
      "take1(input) returns the 1st token and the rest of 'input'.",
      .generator = T_GENERATOR) {
   struct data* x = testit_current_test_data();
   S input = x->input;
-  if (!stream.empty(input)) {
+  if (!stream.null(input)) {
     Tok expect = x->expect;
     Tok actual = stream.take1(input);
     c_assert(!expect.none);
@@ -36,12 +36,12 @@ test("if !empty(input) := true, then "
   }
 }
 
-test("if empty(input) := true, then "
+test("if null(input) := true, then "
      "take1(input) returns nothing.",
      .generator = T_GENERATOR) {
   struct data* x = testit_current_test_data();
   S input = x->input;
-  if (stream.empty(input)) {
+  if (stream.null(input)) {
     Tok expect = x->expect;
     Tok actual = stream.take1(input);
     c_assert(expect.none);

--- a/test/testit/src/cparsec3/stream/test_stream_takeN.h
+++ b/test/testit/src/cparsec3/stream/test_stream_takeN.h
@@ -17,11 +17,7 @@ static inline bool toks_eq(Toks a, Toks b) {
   if (b.none) {
     return a.none;
   }
-  tie((Tokens(S) a_chunk, S a_rest), a.value);
-  tie((Tokens(S) b_chunk, S b_rest), b.value);
-  return eq(a_chunk.length, b_chunk.length) &&
-         !strncmp(a_chunk.value, b_chunk.value, a_chunk.length) &&
-         eq(a_rest, b_rest);
+  return eq(a.value.e1, b.value.e1) && eq(a.value.e2, b.value.e2);
 }
 
 test("if (n <= 0) := true, then "
@@ -39,26 +35,26 @@ test("if (n <= 0) := true, then "
   }
 }
 
-test("if (n > 0) && empty(input) := true, then "
+test("if (n > 0) && null(input) := true, then "
      "takeN(n, input) returns nothing. (i.e. end of input)",
      .generator = T_GENERATOR) {
   struct data* x = testit_current_test_data();
   int n = x->n;
   S input = x->input;
-  if (n > 0 && stream.empty(input)) {
+  if (n > 0 && stream.null(input)) {
     Toks actual = stream.takeN(n, input);
     c_assert(actual.none);
   }
 }
 
-test("if (n > 0) && !empty(input) := true, then "
+test("if (n > 0) && !null(input) := true, then "
      "takeN(n, input) returns a chunk whose length is n at most "
      "and the rest of `input`.",
      .generator = T_GENERATOR) {
   struct data* x = testit_current_test_data();
   int n = x->n;
   S input = x->input;
-  if (n > 0 && !stream.empty(input)) {
+  if (n > 0 && !stream.null(input)) {
     Toks expect = x->expect;
     Toks actual = stream.takeN(n, input);
     c_assert(!expect.none);


### PR DESCRIPTION
- `Token(String)` and `Tokens(String)` are now synonym of `char` and `String` respectively. (not `typedef`)
- renamed `Stream(S).empty(S s)` to `Stream(S).null(S s)`
- added `Stream(S).chunkToTokens(Tokens(S) chk)`
- added `Stream(S).chunkLength(Tokens(S) chk)`
