### PR TITLE
Refactor/parsec

### DIFF
--- a/example/parsec/src/parsec.c
+++ b/example/parsec/src/parsec.c
@@ -80,6 +80,7 @@ int main(void) {
   printf("\n");
 
   __auto_type P = trait(ParsecPrim(S, Token(S)));
+  __auto_type Q = trait(ParsecPrim(S, Tokens(S)));
   __auto_type D = trait(ParsecDeriv(S));
   {
     __auto_type p = P.parseError((ParseError(S)){0});
@@ -110,5 +111,6 @@ int main(void) {
     g_parseTest(p, "");
     g_parseTest(p, "foo");
     g_parseTest(p, "bar");
+    g_parseTest(Q.label("foo", p), "bar");
   }
 }

--- a/example/parsec/src/parsec.c
+++ b/example/parsec/src/parsec.c
@@ -3,33 +3,71 @@
 #include <cparsec3/base/base_generics.h>
 
 #include <cparsec3/parsec/ParsecBase.h>
-#include <cparsec3/parsec/ParsecDeriv.h>
-#include <cparsec3/parsec/ParsecFailure.h>
-#include <cparsec3/parsec/ParsecPrim.h>
 #include <cparsec3/parsec/ParsecRunner.h>
+
+#include <cparsec3/parsec/ParsecFailure.h>
+#include <cparsec3/parsec/ParsecFailure1.h>
+
+#include <cparsec3/parsec/ParsecPrim.h>
+#include <cparsec3/parsec/ParsecPrim1.h>
+
+#include <cparsec3/parsec/ParsecDeriv.h>
 
 // -----------------------------------------------------------------------
 #include "cparsec3/stream/stream_string.h"
 
+#define PARSER_RETURN_TYPES(S) Token(S), Tokens(S), None
+
+#define TRAIT_PARSECRUNNER(S, T) trait(ParsecRunner(S, T))
+#define GENERIC_PARSECRUNNER(S, p)                                       \
+  GENERIC(p, Parsec, TRAIT_PARSECRUNNER, BIND(S, PARSER_RETURN_TYPES(S)))
+
+#define trait_ParsecLibrary(S)                                           \
+  trait_ParsecBase(S);                                                   \
+                                                                         \
+  trait_ParsecRunner(S, Token(S));                                       \
+  trait_ParsecRunner(S, Tokens(S));                                      \
+  trait_ParsecRunner(S, None);                                           \
+                                                                         \
+  trait_ParsecPrim1(S);                                                  \
+  trait_ParsecPrim(S, Token(S));                                         \
+  trait_ParsecPrim(S, Tokens(S));                                        \
+                                                                         \
+  trait_ParsecFailure1(S);                                               \
+  trait_ParsecFailure(S, Token(S));                                      \
+  trait_ParsecFailure(S, Tokens(S));                                     \
+                                                                         \
+  trait_ParsecDeriv(S);                                                  \
+                                                                         \
+  END_OF_STATEMENTS
+
+#define impl_ParsecLibrary(S)                                            \
+  impl_ParsecBase(S);                                                    \
+                                                                         \
+  impl_ParsecRunner(S, Token(S));                                        \
+  impl_ParsecRunner(S, Tokens(S));                                       \
+  impl_ParsecRunner(S, None);                                            \
+                                                                         \
+  impl_ParsecPrim1(S);                                                   \
+  impl_ParsecPrim(S, Token(S));                                          \
+  impl_ParsecPrim(S, Tokens(S));                                         \
+                                                                         \
+  impl_ParsecFailure1(S);                                                \
+  impl_ParsecFailure(S, Token(S));                                       \
+  impl_ParsecFailure(S, Tokens(S));                                      \
+                                                                         \
+  impl_ParsecDeriv(S);                                                   \
+                                                                         \
+  END_OF_STATEMENTS
+
+trait_ParsecLibrary(String);
+impl_ParsecLibrary(String);
+
+// -----------------------------------------------------------------------
 #define S String
 
-trait_ParsecBase(S);
-trait_ParsecPrim(S, Token(S));
-trait_ParsecFailure(S, Token(S));
-trait_ParsecDeriv(S);
-
-// trait_ParsecRunner(S, None);
-trait_ParsecRunner(S, Token(S));
-trait_ParsecRunner(S, Tokens(S));
-
-impl_ParsecBase(S);
-impl_ParsecPrim(S, Token(S));
-impl_ParsecFailure(S, Token(S));
-impl_ParsecDeriv(S);
-
-// impl_ParsecRunner(S, None);
-impl_ParsecRunner(S, Token(S));
-impl_ParsecRunner(S, Tokens(S));
+#define g_parseTest(p, input)                                            \
+  GENERIC_PARSECRUNNER(String, p).parseTest(p, input)
 
 int main(void) {
   for (int x = 0; x < 256; ++x) {
@@ -41,38 +79,36 @@ int main(void) {
   }
   printf("\n");
 
-  __auto_type R = trait(ParsecRunner(S, Token(S)));
   __auto_type P = trait(ParsecPrim(S, Token(S)));
   __auto_type D = trait(ParsecDeriv(S));
   {
     __auto_type p = P.parseError((ParseError(S)){0});
-    R.parseTest(p, "");
-    R.parseTest(p, "foo");
-    R.parseTest(p, "bar");
+    g_parseTest(p, "");
+    g_parseTest(p, "foo");
+    g_parseTest(p, "bar");
   }
   {
     __auto_type p = D.single('f');
-    R.parseTest(p, "");
-    R.parseTest(p, "foo");
-    R.parseTest(p, "bar");
+    g_parseTest(p, "");
+    g_parseTest(p, "foo");
+    g_parseTest(p, "bar");
   }
   {
     __auto_type p = D.anySingle();
-    R.parseTest(p, "");
-    R.parseTest(p, "foo");
-    R.parseTest(p, "bar");
+    g_parseTest(p, "");
+    g_parseTest(p, "foo");
+    g_parseTest(p, "bar");
   }
   {
     __auto_type p = D.anySingleBut('f');
-    R.parseTest(p, "");
-    R.parseTest(p, "foo");
-    R.parseTest(p, "bar");
+    g_parseTest(p, "");
+    g_parseTest(p, "foo");
+    g_parseTest(p, "bar");
   }
   {
-    __auto_type R = trait(ParsecRunner(S, Tokens(S)));
     __auto_type p = D.chunk("foo");
-    R.parseTest(p, "");
-    R.parseTest(p, "foo");
-    R.parseTest(p, "bar");
+    g_parseTest(p, "");
+    g_parseTest(p, "foo");
+    g_parseTest(p, "bar");
   }
 }

--- a/include/cparsec3/parsec/ParsecBase.h
+++ b/include/cparsec3/parsec/ParsecBase.h
@@ -11,10 +11,6 @@
   typedef_ParseState(S);                                                 \
   trait_ParseError(S);                                                   \
                                                                          \
-  typedef_Parsec(S, None);                                               \
-  typedef_Parsec(S, Token(S));                                           \
-  typedef_Parsec(S, Tokens(S));                                          \
-                                                                         \
   C_API_END                                                              \
   END_OF_STATEMENTS
 

--- a/include/cparsec3/parsec/ParsecDeriv.h
+++ b/include/cparsec3/parsec/ParsecDeriv.h
@@ -2,6 +2,7 @@
 #include "../base/base_generics.h"
 
 #include "ParsecPrim.h"
+#include "ParsecPrim1.h"
 
 // -----------------------------------------------------------------------
 #define ParsecDeriv(S) TYPE_NAME(ParsecDeriv, S)
@@ -9,11 +10,6 @@
 // -----------------------------------------------------------------------
 #define trait_ParsecDeriv(S)                                             \
   C_API_BEGIN                                                            \
-                                                                         \
-  /* tokensMatcher (for `tokens` parser) */                              \
-  typedef_Fn_r(Tokens(S), Tokens(S), bool);                              \
-  /* tokenPredicate (for `takeWhileP`, `takeWhile1P` parsers) */         \
-  typedef_Fn_r(Token(S), bool);                                          \
                                                                          \
   typedef struct ParsecDeriv(S) ParsecDeriv(S);                          \
   struct ParsecDeriv(S) {                                                \
@@ -23,15 +19,6 @@
     Parsec(S, Token(S)) (*anySingleBut)(Token(S) t);                     \
     Parsec(S, Token(S)) (*oneOf)(Array(Token(S)) ts);                    \
     Parsec(S, Token(S)) (*noneOf)(Array(Token(S)) ts);                   \
-                                                                         \
-    Parsec(S, Tokens(S)) (*tokens)(Fn(Tokens(S), Tokens(S), bool) test,  \
-                                   Tokens(S) pattern);                   \
-    Parsec(S, Tokens(S)) (*takeWhileP)(Maybe(String) name,               \
-                                       Fn(Token(S), bool) pred);         \
-    Parsec(S, Tokens(S)) (*takeWhile1P)(Maybe(String) name,              \
-                                        Fn(Token(S), bool) pred);        \
-    Parsec(S, Tokens(S)) (*takeP)(Maybe(String) name, int n);            \
-                                                                         \
     Parsec(S, Tokens(S)) (*chunk)(Tokens(S) chk);                        \
     Parsec(S, Tokens(S)) (*takeRest)(void);                              \
   };                                                                     \
@@ -50,8 +37,6 @@
   impl_anySingle(S);                                                     \
   impl_anySingleBut(S);                                                  \
                                                                          \
-  impl_tokens(S);                                                        \
-                                                                         \
   impl_chunk(S);                                                         \
                                                                          \
   ParsecDeriv(S) Trait(ParsecDeriv(S)) {                                 \
@@ -62,12 +47,6 @@
         .anySingleBut = FUNC_NAME(anySingleBut, S),                      \
         .oneOf = 0,                                                      \
         .noneOf = 0,                                                     \
-                                                                         \
-        .tokens = FUNC_NAME(tokens, S),                                  \
-        .takeWhileP = 0,                                                 \
-        .takeWhile1P = 0,                                                \
-        .takeP = 0,                                                      \
-                                                                         \
         .chunk = FUNC_NAME(chunk, S),                                    \
         .takeRest = 0,                                                   \
     };                                                                   \
@@ -155,60 +134,6 @@
   END_OF_STATEMENTS
 
 // -----------------------------------------------------------------------
-/* tokens(test, pattern) */
-#define impl_tokens(S)                                                   \
-                                                                         \
-  typedef_Fn_r(Fn(Tokens(S), Tokens(S), bool), Tokens(S),                \
-               UnParser(S, Tokens(S)));                                  \
-                                                                         \
-  fn(FUNC_NAME(tokensImpl, S),                                           \
-     Fn(Tokens(S), Tokens(S), bool), /* test */                          \
-     Tokens(S),                      /* pattern */                       \
-     UnParserArgs(                                                       \
-         S, Tokens(S)) /* s -> cok -> cerr -> eok -> eerr -> reply*/     \
-  ) {                                                                    \
-    g_bind((test, pattern, s, cok, , eok, eerr), *args);                 \
-    Stream(S) IS = trait(Stream(S));                                     \
-    int n = IS.chunkLength(pattern);                                     \
-    __auto_type maybe = IS.takeN(n, s.input);                            \
-    if (maybe.none) {                                                    \
-      ParseError(S) e = {                                                \
-          .offset = s.offset,                                            \
-          .unexpected.value.type = END_OF_INPUT,                         \
-          .expecting = NULL,                                             \
-      };                                                                 \
-      return fn_apply(eerr, e, s);                                       \
-    }                                                                    \
-    Tokens(S) actual = maybe.value.e1;                                   \
-    if (!fn_apply(test, pattern, actual)) {                              \
-      ParseError(S) e = {                                                \
-          .offset = s.offset,                                            \
-          .unexpected.value = {.type = TOKENS,                           \
-                               .tokens = IS.chunkToTokens(actual)},      \
-          .expecting = NULL,                                             \
-      };                                                                 \
-      return fn_apply(eerr, e, s);                                       \
-    }                                                                    \
-    int m = IS.chunkLength(actual);                                      \
-    s.input = maybe.value.e2;                                            \
-    s.offset += m;                                                       \
-    if (!m) {                                                            \
-      return fn_apply(eok, actual, s, NULL);                             \
-    }                                                                    \
-    return fn_apply(cok, actual, s, NULL);                               \
-  }                                                                      \
-                                                                         \
-  static Parsec(S, Tokens(S)) FUNC_NAME(tokens, S)(                      \
-      Fn(Tokens(S), Tokens(S), bool) test, Tokens(S) pattern) {          \
-    __auto_type f = FUNC_NAME(tokensImpl, S)();                          \
-    return (Parsec(S, Tokens(S))){                                       \
-        .unParser = fn_apply(f, test, pattern),                          \
-    };                                                                   \
-  }                                                                      \
-                                                                         \
-  END_OF_STATEMENTS
-
-// -----------------------------------------------------------------------
 /* chunk(pattern) */
 #define impl_chunk(S)                                                    \
                                                                          \
@@ -218,7 +143,7 @@
                                                                          \
   static Parsec(S, Tokens(S)) FUNC_NAME(chunk, S)(Tokens(S) chk) {       \
     __auto_type f = FUNC_NAME(chunkTest, S)();                           \
-    return FUNC_NAME(tokens, S)(f, chk);                                 \
+    return trait(ParsecPrim1(S)).tokens(f, chk);                         \
   }                                                                      \
                                                                          \
   END_OF_STATEMENTS

--- a/include/cparsec3/parsec/ParsecFailure1.h
+++ b/include/cparsec3/parsec/ParsecFailure1.h
@@ -4,32 +4,33 @@
 #include "ParsecPrim.h"
 
 // -----------------------------------------------------------------------
-#define ParsecFailure(...) TYPE_NAME(ParsecFailure, __VA_ARGS__)
+#define ParsecFailure1(...) TYPE_NAME(ParsecFailure1, __VA_ARGS__)
 
 // -----------------------------------------------------------------------
-#define trait_ParsecFailure(S, T)                                        \
+#define trait_ParsecFailure1(S)                                          \
   C_API_BEGIN                                                            \
                                                                          \
-  typedef struct ParsecFailure(S, T) ParsecFailure(S, T);                \
-  struct ParsecFailure(S, T) {                                           \
-    Parsec(S, T) (*failure)(Maybe(ErrorItem(Token(S))) unexpected,       \
-                            List(ErrorItem(Token(S))) expected);         \
-    Parsec(S, T) (*unexpected)(ErrorItem(Token(S)) item);                \
+  typedef struct ParsecFailure1(S) ParsecFailure1(S);                    \
+  struct ParsecFailure1(S) {                                             \
+    Parsec(S, None) (*registerParseError)(ParseError(S) err);            \
+    Parsec(S, None) (*registerFailure)(                                  \
+        Maybe(ErrorItem(Token(S))) unexpected,                           \
+        List(ErrorItem(Token(S))) expected);                             \
   };                                                                     \
                                                                          \
-  ParsecFailure(S, T) Trait(ParsecFailure(S, T));                        \
+  ParsecFailure1(S) Trait(ParsecFailure1(S));                            \
                                                                          \
   C_API_END                                                              \
   END_OF_STATEMENTS
 
 // -----------------------------------------------------------------------
-#define impl_ParsecFailure(S, T)                                         \
+#define impl_ParsecFailure1(S)                                           \
   C_API_BEGIN                                                            \
                                                                          \
-  ParsecFailure(S, T) Trait(ParsecFailure(S, T)) {                       \
-    return (ParsecFailure(S, T)){                                        \
-        .failure = 0,                                                    \
-        .unexpected = 0,                                                 \
+  ParsecFailure1(S) Trait(ParsecFailure1(S)) {                           \
+    return (ParsecFailure1(S)){                                          \
+        .registerParseError = 0,                                         \
+        .registerFailure = 0,                                            \
     };                                                                   \
   }                                                                      \
                                                                          \

--- a/include/cparsec3/parsec/ParsecPrim.h
+++ b/include/cparsec3/parsec/ParsecPrim.h
@@ -20,7 +20,7 @@
     Parsec(S, T) (*tryp)(Parsec(S, T) p);                                \
     Parsec(S, T) (*lookAhead)(Parsec(S, T) p);                           \
     Parsec(S, None) (*notFollowedBy)(Parsec(S, T) p);                    \
-    Parsec(S, None) (*eof)(void);                                        \
+                                                                         \
     Parsec(S, T) (*token)(Fn(Token(S), Maybe(T)) testToken,              \
                           Hints(Token(S)) expecting);                    \
   };                                                                     \
@@ -34,6 +34,7 @@
 #define impl_ParsecPrim(S, T)                                            \
   C_API_BEGIN                                                            \
                                                                          \
+  typedef_Fn(Parsec(S, T), UnParser(S, T));                              \
   impl_parseError(S, T);                                                 \
   impl_tryp(S, T);                                                       \
   impl_token(S, T);                                                      \
@@ -46,7 +47,7 @@
         .tryp = FUNC_NAME(tryp, S, T),                                   \
         .lookAhead = 0,                                                  \
         .notFollowedBy = 0,                                              \
-        .eof = 0,                                                        \
+                                                                         \
         .token = FUNC_NAME(token, S, T),                                 \
     };                                                                   \
   }                                                                      \
@@ -84,7 +85,6 @@
     return fn_apply(f, e, s);                                            \
   }                                                                      \
                                                                          \
-  typedef_Fn_r(Parsec(S, T), UnParser(S, T));                            \
   fn(FUNC_NAME(trypImpl, S, T), /* name */                               \
      Parsec(S, T),              /* p : underlying parser */              \
      UnParserArgs(S,                                                     \

--- a/include/cparsec3/parsec/ParsecPrim1.h
+++ b/include/cparsec3/parsec/ParsecPrim1.h
@@ -1,0 +1,106 @@
+/* -*- coding: utf-8-unix -*- */
+#include "../base/base_generics.h"
+
+#include "parsec.h"
+
+// -----------------------------------------------------------------------
+#define ParsecPrim1(...) TYPE_NAME(ParsecPrim, __VA_ARGS__)
+
+// -----------------------------------------------------------------------
+#define trait_ParsecPrim1(S)                                             \
+  C_API_BEGIN                                                            \
+                                                                         \
+  /* tokensMatcher (for `tokens` parser) */                              \
+  typedef_Fn_r(Tokens(S), Tokens(S), bool);                              \
+  /* tokenPredicate (for `takeWhileP`, `takeWhile1P` parsers) */         \
+  typedef_Fn_r(Token(S), bool);                                          \
+                                                                         \
+  typedef struct ParsecPrim1(S) ParsecPrim1(S);                          \
+  struct ParsecPrim1(S) {                                                \
+    Parsec(S, None) (*eof)(void);                                        \
+    Parsec(S, Tokens(S)) (*tokens)(Fn(Tokens(S), Tokens(S), bool) test,  \
+                                   Tokens(S) pattern);                   \
+    Parsec(S, Tokens(S)) (*takeWhileP)(Maybe(String) name,               \
+                                       Fn(Token(S), bool) pred);         \
+    Parsec(S, Tokens(S)) (*takeWhile1P)(Maybe(String) name,              \
+                                        Fn(Token(S), bool) pred);        \
+    Parsec(S, Tokens(S)) (*takeP)(Maybe(String) name, int n);            \
+  };                                                                     \
+                                                                         \
+  ParsecPrim1(S) Trait(ParsecPrim1(S));                                  \
+                                                                         \
+  C_API_END                                                              \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_ParsecPrim1(S)                                              \
+  C_API_BEGIN                                                            \
+                                                                         \
+  impl_tokens(S);                                                        \
+                                                                         \
+  ParsecPrim1(S) Trait(ParsecPrim1(S)) {                                 \
+    return (ParsecPrim1(S)){                                             \
+        .eof = 0,                                                        \
+        .tokens = FUNC_NAME(tokens, S),                                  \
+        .takeWhileP = 0,                                                 \
+        .takeWhile1P = 0,                                                \
+        .takeP = 0,                                                      \
+    };                                                                   \
+  }                                                                      \
+                                                                         \
+  C_API_END                                                              \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+/* tokens(test, pattern) */
+#define impl_tokens(S)                                                   \
+                                                                         \
+  typedef_Fn_r(Fn(Tokens(S), Tokens(S), bool), Tokens(S),                \
+               UnParser(S, Tokens(S)));                                  \
+                                                                         \
+  fn(FUNC_NAME(tokensImpl, S),                                           \
+     Fn(Tokens(S), Tokens(S), bool), /* test */                          \
+     Tokens(S),                      /* pattern */                       \
+     UnParserArgs(                                                       \
+         S, Tokens(S)) /* s -> cok -> cerr -> eok -> eerr -> reply*/     \
+  ) {                                                                    \
+    g_bind((test, pattern, s, cok, , eok, eerr), *args);                 \
+    Stream(S) IS = trait(Stream(S));                                     \
+    int n = IS.chunkLength(pattern);                                     \
+    __auto_type maybe = IS.takeN(n, s.input);                            \
+    if (maybe.none) {                                                    \
+      ParseError(S) e = {                                                \
+          .offset = s.offset,                                            \
+          .unexpected.value.type = END_OF_INPUT,                         \
+          .expecting = NULL,                                             \
+      };                                                                 \
+      return fn_apply(eerr, e, s);                                       \
+    }                                                                    \
+    Tokens(S) actual = maybe.value.e1;                                   \
+    if (!fn_apply(test, pattern, actual)) {                              \
+      ParseError(S) e = {                                                \
+          .offset = s.offset,                                            \
+          .unexpected.value = {.type = TOKENS,                           \
+                               .tokens = IS.chunkToTokens(actual)},      \
+          .expecting = NULL,                                             \
+      };                                                                 \
+      return fn_apply(eerr, e, s);                                       \
+    }                                                                    \
+    int m = IS.chunkLength(actual);                                      \
+    s.input = maybe.value.e2;                                            \
+    s.offset += m;                                                       \
+    if (!m) {                                                            \
+      return fn_apply(eok, actual, s, NULL);                             \
+    }                                                                    \
+    return fn_apply(cok, actual, s, NULL);                               \
+  }                                                                      \
+                                                                         \
+  static Parsec(S, Tokens(S)) FUNC_NAME(tokens, S)(                      \
+      Fn(Tokens(S), Tokens(S), bool) test, Tokens(S) pattern) {          \
+    __auto_type f = FUNC_NAME(tokensImpl, S)();                          \
+    return (Parsec(S, Tokens(S))){                                       \
+        .unParser = fn_apply(f, test, pattern),                          \
+    };                                                                   \
+  }                                                                      \
+                                                                         \
+  END_OF_STATEMENTS

--- a/include/cparsec3/parsec/ParsecRunner.h
+++ b/include/cparsec3/parsec/ParsecRunner.h
@@ -9,6 +9,7 @@
 // -----------------------------------------------------------------------
 #define trait_ParsecRunner(S, T)                                         \
   C_API_BEGIN                                                            \
+  typedef_Parsec(S, T);                                                  \
   /* ---- trait ParsecRunner(S, T) */                                    \
   typedef struct ParsecRunner(S, T) ParsecRunner(S, T);                  \
   struct ParsecRunner(S, T) {                                            \


### PR DESCRIPTION
Refactored and sorted out parsec lib.
- `ParsecPrim(S, T)` : provides primitive parser combinators
- `ParsecPrim1(S)` : provides primitive parser combinators
- `ParsecDeriv(S)` : provides derived parser combinators
- `ParsecFailure(S, T)` : provides parser combinators for error reporting
- `ParsecFailure1(S)` : provides parser combinators for error reporting
