### PR TITLE
removed mem_asprintf() and mem_vasprintf() ; unused

### DIFF
--- a/include/cparsec3/base/mem.h
+++ b/include/cparsec3/base/mem.h
@@ -109,8 +109,6 @@ void mem_free(void* p);
 
 // -----------------------------------------------------------------------
 #include <stdarg.h>
-int mem_asprintf(char** strp, const char* fmt, ...);
-int mem_vasprintf(char** strp, const char* fmt, va_list ap);
 
 typedef struct CharBuff CharBuff;
 struct CharBuff {

--- a/src/cparsec3/base/mem.c
+++ b/src/cparsec3/base/mem.c
@@ -169,47 +169,6 @@ void mem_free(void* p) {
 }
 
 // -----------------------------------------------------------------------
-int mem_asprintf(char** strp, const char* fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  int ret = mem_vasprintf(strp, fmt, ap);
-  va_end(ap);
-  return ret;
-}
-
-int mem_vasprintf(char** strp, const char* fmt, va_list ap) {
-  assert(strp && "Null pointer");
-  assert(fmt && "Null pointer");
-
-  va_list ap2;
-
-  va_copy(ap2, ap);
-  int len = vsnprintf(NULL, 0, fmt, ap2);
-  va_end(ap2);
-  if (len < 0) {
-    *strp = NULL;
-    return -1;
-  }
-
-  char* buf = mem_malloc(len + 1);
-  if (!buf) {
-    *strp = NULL;
-    return -1;
-  }
-
-  va_copy(ap2, ap);
-  int l = vsnprintf(buf, len + 1, fmt, ap2);
-  va_end(ap2);
-  if (l != len) {
-    mem_free(buf);
-    *strp = NULL;
-    return -1;
-  }
-
-  *strp = buf;
-  return len;
-}
-
 int mem_printf(CharBuff* b, const char* fmt, ...) {
   va_list ap;
   va_start(ap, fmt);


### PR DESCRIPTION
use `mem_printf(b, fmt, ...)` and `mem_vprntf(b, fmt, ap)` instead.