### PR TITLE
devided reachOffset() into advanceTo() and lineTextOf()

### DIFF
--- a/include/cparsec3/parsec/ParsecRunner.h
+++ b/include/cparsec3/parsec/ParsecRunner.h
@@ -100,9 +100,9 @@
     if (!result.success) {                                               \
       PosStateT(S) PS = trait(PosState(S));                              \
       PosState(S) pst = PS.create("", input);                            \
-      String lineText =                                                  \
-          trait(Stream(S)).reachOffset(result.err.offset, &pst);         \
-      PS.print(lineText, pst);                                           \
+      Stream(S) SS = trait(Stream(S));                                   \
+      pst = SS.advanceTo(result.err.offset, pst);                        \
+      PS.print(SS.lineTextOf(pst), pst);                                 \
       FUNC_NAME(print, ParseError(S))(result.err);                       \
       printf("\n");                                                      \
       return false;                                                      \

--- a/include/cparsec3/parsec/posstate.h
+++ b/include/cparsec3/parsec/posstate.h
@@ -11,8 +11,9 @@
 #define typedef_PosState(S)                                              \
   typedef struct PosState(S) PosState(S);                                \
   struct PosState(S) {                                                   \
-    S input; /* a Stream */                                              \
-    Offset offset;                                                       \
+    S input;           /**< rest of the unprocessed token-stream */      \
+    Offset offset;     /**< offset of the current position */            \
+    Offset lineOffset; /**< offset of the current line */                \
     SourcePos sourcePos;                                                 \
     size_t tabWidth;                                                     \
     String linePrefix;                                                   \
@@ -39,6 +40,7 @@
     return (PosState(S)){                                                \
         .input = input,                                                  \
         .offset = 0,                                                     \
+        .lineOffset = 0,                                                 \
         .sourcePos.name = name,                                          \
         .sourcePos.line = 1,                                             \
         .sourcePos.column = 1,                                           \

--- a/include/cparsec3/parsec/stream.h
+++ b/include/cparsec3/parsec/stream.h
@@ -10,13 +10,13 @@
 
 #define trait_Stream(S)                                                  \
   C_API_BEGIN                                                            \
-  /* ---- */                                                             \
+                                                                         \
   typedef_Tuple(Token(S), S);                                            \
   typedef_Tuple(Tokens(S), S);                                           \
   trait_Maybe(Tuple(Token(S), S));                                       \
   trait_Maybe(Tuple(Tokens(S), S));                                      \
   trait_PosState(S);                                                     \
-  /* ---- */                                                             \
+                                                                         \
   typedef struct Stream(S) Stream(S);                                    \
   struct Stream(S) {                                                     \
     bool (*null)(S s);                                                   \
@@ -26,10 +26,13 @@
     Maybe(Tuple(Token(S), S)) (*take1)(S s);                             \
     Maybe(Tuple(Tokens(S), S)) (*takeN)(int n, S s);                     \
                                                                          \
-    /** update PosState and returns current-line-text */                 \
-    String (*reachOffset)(Offset o, PosState(S) * pst);                  \
+    /** update PosState */                                               \
+    PosState(S) (*advanceTo)(Offset o, PosState(S) pst);                 \
+    /** constructs text of the line */                                   \
+    String (*lineTextOf)(PosState(S) pst);                               \
   };                                                                     \
+                                                                         \
   Stream(S) Trait(Stream(S));                                            \
-  /* ---- */                                                             \
+                                                                         \
   C_API_END                                                              \
   END_OF_STATEMENTS


### PR DESCRIPTION
- added `PosState(S).lineOffset`
- added `Stream(S).advanceTo(o, pst)`
- added `Stream(S).lineTextOf(pst)`
- removed `Stream(S).reachOffset(o, pst)`

Note that `lineOffset` represents the number of tokens in the past lines processed.
Against to that, `offset` represents the number of whole tokens processed.

i.e. lineOffset <= offset