### PR TITLE
fixed: Eq, Ord, Show are not necessarily be required for containers

### DIFF
--- a/include/cparsec3/base/array.h
+++ b/include/cparsec3/base/array.h
@@ -37,10 +37,6 @@
     Array(T) (*from_array)(size_t n, T * a);                             \
   };                                                                     \
   ArrayT(T) Trait(Array(T));                                             \
-  /* ---- instance Eq(Array(T)) */                                       \
-  trait_Eq(Array(T));                                                    \
-  /* ---- instance Ord(Array(T)) */                                      \
-  trait_Ord(Array(T));                                                   \
   /* ---- instance Itr(Array(T)) */                                      \
   typedef T Item(Array(T));                                              \
   typedef struct Itr(Array(T)) Itr(Array(T));                            \
@@ -127,37 +123,6 @@
         .from_array = FUNC_NAME(from_array, Array(T)),                   \
     };                                                                   \
   }                                                                      \
-  /* ---- instance Eq(Array(T)) */                                       \
-  static bool FUNC_NAME(eq, Eq(Array(T)))(Array(T) a, Array(T) b) {      \
-    if (a.length != b.length) {                                          \
-      return false;                                                      \
-    }                                                                    \
-    if (a.data == b.data) {                                              \
-      return true;                                                       \
-    }                                                                    \
-    for (size_t i = 0; i < a.length; ++i) {                              \
-      if (trait(Eq(T)).neq(a.data[i], b.data[i])) {                      \
-        return false;                                                    \
-      }                                                                  \
-    }                                                                    \
-    return true;                                                         \
-  }                                                                      \
-  instance_Eq(Array(T), FUNC_NAME(eq, Eq(Array(T))));                    \
-  /* ---- instance Ord(Array(T)) */                                      \
-  static int FUNC_NAME(cmp, Ord(Array(T)))(Array(T) a, Array(T) b) {     \
-    if (a.data == b.data) {                                              \
-      return trait(Ord(uint64_t)).cmp(a.length, b.length);               \
-    }                                                                    \
-    size_t n = (a.length <= b.length ? a.length : b.length);             \
-    for (size_t i = 0; i < n; ++i) {                                     \
-      int o = trait(Ord(T)).cmp(a.data[i], b.data[i]);                   \
-      if (o) {                                                           \
-        return o;                                                        \
-      }                                                                  \
-    }                                                                    \
-    return (a.length < b.length ? -1 : 1);                               \
-  }                                                                      \
-  instance_Ord(Array(T), FUNC_NAME(cmp, Ord(Array(T))));                 \
   /* ---- instance Itr(Array(T))*/                                       \
   static T* FUNC_NAME(ptr, Itr(Array(T)))(Itr(Array(T)) it) {            \
     return it.a.data;                                                    \

--- a/include/cparsec3/base/base.h
+++ b/include/cparsec3/base/base.h
@@ -35,10 +35,17 @@ FOREACH(trait_Array, TYPESET(ALL));
 FOREACH(trait_List, TYPESET(ALL));
 FOREACH(trait_Maybe, TYPESET(ALL));
 
-trait_Show(Array(char));
-trait_Show(Array(String));
-trait_Show(List(char));
-trait_Show(List(String));
+FOREACH(trait_Eq, APPLY(Array, TYPESET(ALL)));
+FOREACH(trait_Eq, APPLY(List, TYPESET(ALL)));
+FOREACH(trait_Eq, APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(trait_Ord, APPLY(Array, TYPESET(ALL)));
+FOREACH(trait_Ord, APPLY(List, TYPESET(ALL)));
+FOREACH(trait_Ord, APPLY(Maybe, TYPESET(ALL)));
+
+FOREACH(trait_Show, APPLY(Array, TYPESET(ALL)));
+FOREACH(trait_Show, APPLY(List, TYPESET(ALL)));
+FOREACH(trait_Show, APPLY(Maybe, TYPESET(ALL)));
 
 #if !defined(CPARSEC_ENABLE_NESTED_CONTAINER)
 #define TYPESET_COMPONENT TYPESET(ALL)
@@ -52,4 +59,17 @@ FOREACH(trait_Mem, TYPESET_CONTAINER);
 FOREACH(trait_Array, TYPESET_CONTAINER);
 FOREACH(trait_List, TYPESET_CONTAINER);
 FOREACH(trait_Maybe, TYPESET_CONTAINER);
+
+FOREACH(trait_Eq, APPLY(Array, TYPESET_CONTAINER));
+FOREACH(trait_Eq, APPLY(List, TYPESET_CONTAINER));
+FOREACH(trait_Eq, APPLY(Maybe, TYPESET_CONTAINER));
+
+FOREACH(trait_Ord, APPLY(Array, TYPESET_CONTAINER));
+FOREACH(trait_Ord, APPLY(List, TYPESET_CONTAINER));
+FOREACH(trait_Ord, APPLY(Maybe, TYPESET_CONTAINER));
+
+FOREACH(trait_Show, APPLY(Array, TYPESET_CONTAINER));
+FOREACH(trait_Show, APPLY(List, TYPESET_CONTAINER));
+FOREACH(trait_Show, APPLY(Maybe, TYPESET_CONTAINER));
+
 #endif

--- a/include/cparsec3/base/eq.h
+++ b/include/cparsec3/base/eq.h
@@ -31,3 +31,62 @@
   }                                                                      \
   C_API_END                                                              \
   END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_Eq_Maybe(T)                                                 \
+  C_API_BEGIN                                                            \
+  static bool FUNC_NAME(eq, Eq(Maybe(T)))(Maybe(T) a, Maybe(T) b) {      \
+    if (a.none && b.none) {                                              \
+      return true;                                                       \
+    }                                                                    \
+    if (a.none != b.none) {                                              \
+      return false;                                                      \
+    }                                                                    \
+    return trait(Eq(T)).eq(a.value, b.value);                            \
+  }                                                                      \
+  instance_Eq(Maybe(T), FUNC_NAME(eq, Eq(Maybe(T))));                    \
+  C_API_END                                                              \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_Eq_Array(T)                                                 \
+  C_API_BEGIN                                                            \
+  static bool FUNC_NAME(eq, Eq(Array(T)))(Array(T) a, Array(T) b) {      \
+    if (a.length != b.length) {                                          \
+      return false;                                                      \
+    }                                                                    \
+    if (a.data == b.data) {                                              \
+      return true;                                                       \
+    }                                                                    \
+    for (size_t i = 0; i < a.length; ++i) {                              \
+      if (trait(Eq(T)).neq(a.data[i], b.data[i])) {                      \
+        return false;                                                    \
+      }                                                                  \
+    }                                                                    \
+    return true;                                                         \
+  }                                                                      \
+  instance_Eq(Array(T), FUNC_NAME(eq, Eq(Array(T))));                    \
+  C_API_END                                                              \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_Eq_List(T)                                                  \
+  C_API_BEGIN                                                            \
+  static bool FUNC_NAME(eq, Eq(List(T)))(List(T) a, List(T) b) {         \
+    for (;;) {                                                           \
+      if (a == b) {                                                      \
+        return true;                                                     \
+      }                                                                  \
+      if (!a || !b) {                                                    \
+        return false;                                                    \
+      }                                                                  \
+      if (trait(Eq(T)).neq(a->head, b->head)) {                          \
+        return false;                                                    \
+      }                                                                  \
+      a = a->tail;                                                       \
+      b = b->tail;                                                       \
+    }                                                                    \
+  }                                                                      \
+  instance_Eq(List(T), FUNC_NAME(eq, Eq(List(T))));                      \
+  C_API_END                                                              \
+  END_OF_STATEMENTS

--- a/include/cparsec3/base/list.h
+++ b/include/cparsec3/base/list.h
@@ -42,10 +42,6 @@
     List(T) (*from_array)(size_t n, T * a);                              \
   };                                                                     \
   ListT(T) Trait(List(T));                                               \
-  /* ---- instance Eq(List(T)) */                                        \
-  trait_Eq(List(T));                                                     \
-  /* ---- instance Ord(List(T)) */                                       \
-  trait_Ord(List(T));                                                    \
   /* ---- instance Itr(List(T)) */                                       \
   typedef T Item(List(T));                                               \
   typedef struct Itr(List(T)) Itr(List(T));                              \
@@ -163,44 +159,6 @@
         .from_array = FUNC_NAME(from_array, List(T)),                    \
     };                                                                   \
   }                                                                      \
-  /* ---- instance Eq(List(T)) */                                        \
-  static bool FUNC_NAME(eq, Eq(List(T)))(List(T) a, List(T) b) {         \
-    for (;;) {                                                           \
-      if (a == b) {                                                      \
-        return true;                                                     \
-      }                                                                  \
-      if (!a || !b) {                                                    \
-        return false;                                                    \
-      }                                                                  \
-      if (trait(Eq(T)).neq(a->head, b->head)) {                          \
-        return false;                                                    \
-      }                                                                  \
-      a = a->tail;                                                       \
-      b = b->tail;                                                       \
-    }                                                                    \
-  }                                                                      \
-  instance_Eq(List(T), FUNC_NAME(eq, Eq(List(T))));                      \
-  /* ---- instance Ord(List(T)) */                                       \
-  static int FUNC_NAME(cmp, Ord(List(T)))(List(T) a, List(T) b) {        \
-    for (;;) {                                                           \
-      if (a == b) {                                                      \
-        return 0;                                                        \
-      }                                                                  \
-      if (!a) {                                                          \
-        return -1;                                                       \
-      }                                                                  \
-      if (!b) {                                                          \
-        return 1;                                                        \
-      }                                                                  \
-      int o = trait(Ord(T)).cmp(a->head, b->head);                       \
-      if (o) {                                                           \
-        return o;                                                        \
-      }                                                                  \
-      a = a->tail;                                                       \
-      b = b->tail;                                                       \
-    }                                                                    \
-  }                                                                      \
-  instance_Ord(List(T), FUNC_NAME(cmp, Ord(List(T))));                   \
   /* ---- instance Itr(List(T))*/                                        \
   static T* FUNC_NAME(ptr, Itr(List(T)))(Itr(List(T)) it) {              \
     return (it.xs ? &(it.xs->head) : 0);                                 \

--- a/include/cparsec3/base/maybe.h
+++ b/include/cparsec3/base/maybe.h
@@ -28,10 +28,6 @@
     Maybe(T) (*just)(T value);                                           \
   };                                                                     \
   MaybeT(T) Trait(Maybe(T));                                             \
-  /* ---- instance Eq(Maybe(T)) */                                       \
-  trait_Eq(Maybe(T));                                                    \
-  /* ---- instance Ord(Maybe(T)) */                                      \
-  trait_Ord(Maybe(T));                                                   \
   /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS
@@ -57,29 +53,6 @@
         .just = FUNC_NAME(just, Maybe(T)),                               \
     };                                                                   \
   }                                                                      \
-  /* ---- instance Eq(Maybe(T)) */                                       \
-  static bool FUNC_NAME(eq, Eq(Maybe(T)))(Maybe(T) a, Maybe(T) b) {      \
-    if (a.none && b.none) {                                              \
-      return true;                                                       \
-    }                                                                    \
-    if (a.none != b.none) {                                              \
-      return false;                                                      \
-    }                                                                    \
-    return trait(Eq(T)).eq(a.value, b.value);                            \
-  }                                                                      \
-  instance_Eq(Maybe(T), FUNC_NAME(eq, Eq(Maybe(T))));                    \
-  /* ---- instance Ord(Maybe(T)) */                                      \
-  static bool FUNC_NAME(le, Ord(Maybe(T)))(Maybe(T) a, Maybe(T) b) {     \
-    if (a.none) {                                                        \
-      return true;                                                       \
-    }                                                                    \
-    if (b.none) {                                                        \
-      return false;                                                      \
-    }                                                                    \
-    return trait(Ord(T)).le(a.value, b.value);                           \
-  }                                                                      \
-  instance_Ord(Maybe(T), FUNC_NAME(le, Ord(Maybe(T))),                   \
-               FUNC_NAME(eq, Eq(Maybe(T))));                             \
   /* ---- */                                                             \
   C_API_END                                                              \
   END_OF_STATEMENTS

--- a/include/cparsec3/base/ord.h
+++ b/include/cparsec3/base/ord.h
@@ -107,3 +107,62 @@
     };                                                                   \
   }                                                                      \
   END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_Ord_Maybe(T)                                                \
+  static int FUNC_NAME(cmp, Ord(Maybe(T)))(Maybe(T) a, Maybe(T) b) {     \
+    if (a.none && b.none) {                                              \
+      return 0;                                                          \
+    }                                                                    \
+    if (a.none) {                                                        \
+      return -1;                                                         \
+    }                                                                    \
+    if (b.none) {                                                        \
+      return 1;                                                          \
+    }                                                                    \
+    return trait(Ord(T)).cmp(a.value, b.value);                          \
+  }                                                                      \
+  instance_Ord(Maybe(T), FUNC_NAME(cmp, Ord(Maybe(T))));                 \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_Ord_Array(T)                                                \
+  static int FUNC_NAME(cmp, Ord(Array(T)))(Array(T) a, Array(T) b) {     \
+    if (a.data == b.data) {                                              \
+      return trait(Ord(size_t)).cmp(a.length, b.length);                 \
+    }                                                                    \
+    size_t n = (a.length <= b.length ? a.length : b.length);             \
+    for (size_t i = 0; i < n; ++i) {                                     \
+      int o = trait(Ord(T)).cmp(a.data[i], b.data[i]);                   \
+      if (o) {                                                           \
+        return o;                                                        \
+      }                                                                  \
+    }                                                                    \
+    return (a.length < b.length ? -1 : 1);                               \
+  }                                                                      \
+  instance_Ord(Array(T), FUNC_NAME(cmp, Ord(Array(T))));                 \
+  END_OF_STATEMENTS
+
+// -----------------------------------------------------------------------
+#define impl_Ord_List(T)                                                 \
+  static int FUNC_NAME(cmp, Ord(List(T)))(List(T) a, List(T) b) {        \
+    for (;;) {                                                           \
+      if (a == b) {                                                      \
+        return 0;                                                        \
+      }                                                                  \
+      if (!a) {                                                          \
+        return -1;                                                       \
+      }                                                                  \
+      if (!b) {                                                          \
+        return 1;                                                        \
+      }                                                                  \
+      int o = trait(Ord(T)).cmp(a->head, b->head);                       \
+      if (o) {                                                           \
+        return o;                                                        \
+      }                                                                  \
+      a = a->tail;                                                       \
+      b = b->tail;                                                       \
+    }                                                                    \
+  }                                                                      \
+  instance_Ord(List(T), FUNC_NAME(cmp, Ord(List(T))));                   \
+  END_OF_STATEMENTS

--- a/include/cparsec3/base/show.h
+++ b/include/cparsec3/base/show.h
@@ -91,3 +91,23 @@ C_API_END
                                                                          \
   C_API_END                                                              \
   END_OF_STATEMENTS
+
+#define impl_Show_Array(T) impl_ShowSeq(Array, T)
+#define impl_Show_List(T) impl_ShowSeq(List, T)
+
+#define impl_Show_Maybe(T)                                               \
+  C_API_BEGIN                                                            \
+  static inline void FUNC_NAME(toString, Show(Maybe(T)))(CharBuff * b,   \
+                                                         Maybe(T) m) {   \
+    if (m.none) {                                                        \
+      mem_printf(b, "Nothing");                                          \
+    } else {                                                             \
+      mem_printf(b, "Just ");                                            \
+      trait(Show(T)).toString(b, m.value);                               \
+    }                                                                    \
+  }                                                                      \
+                                                                         \
+  instance_Show(Maybe(T), FUNC_NAME(toString, Show(Maybe(T))));          \
+                                                                         \
+  C_API_END                                                              \
+  END_OF_STATEMENTS

--- a/include/cparsec3/parsec/parseerror.h
+++ b/include/cparsec3/parsec/parseerror.h
@@ -23,52 +23,11 @@
     };                                                                   \
   };                                                                     \
                                                                          \
-  trait_Eq(ErrorItem(T));                                                \
-  trait_Ord(ErrorItem(T));                                               \
-                                                                         \
   C_API_END                                                              \
   END_OF_STATEMENTS
 
 #define impl_ErrorItem(T)                                                \
   C_API_BEGIN                                                            \
-                                                                         \
-  static bool FUNC_NAME(eq, Eq(ErrorItem(T)))(ErrorItem(T) a,            \
-                                              ErrorItem(T) b) {          \
-    if (a.type != b.type) {                                              \
-      return false;                                                      \
-    }                                                                    \
-    switch (a.type) {                                                    \
-    case LABEL:                                                          \
-      return trait(Eq(String)).eq(a.label, b.label);                     \
-    case TOKENS:                                                         \
-      return trait(Eq(List(T))).eq(a.tokens, b.tokens);                  \
-    case END_OF_INPUT:                                                   \
-      return true;                                                       \
-    default:                                                             \
-      return false;                                                      \
-    }                                                                    \
-  }                                                                      \
-                                                                         \
-  instance_Eq(ErrorItem(T), FUNC_NAME(eq, Eq(ErrorItem(T))));            \
-                                                                         \
-  static int FUNC_NAME(cmp, Ord(ErrorItem(T)))(ErrorItem(T) a,           \
-                                               ErrorItem(T) b) {         \
-    int x = trait(Ord(int)).cmp(a.type, b.type);                         \
-    if (x) {                                                             \
-      return x;                                                          \
-    }                                                                    \
-    switch (a.type) {                                                    \
-    case LABEL:                                                          \
-      return trait(Ord(String)).cmp(a.label, b.label);                   \
-    case TOKENS:                                                         \
-      return trait(Ord(List(T))).cmp(a.tokens, b.tokens);                \
-    case END_OF_INPUT:                                                   \
-    default:                                                             \
-      return 0;                                                          \
-    }                                                                    \
-  }                                                                      \
-                                                                         \
-  instance_Ord(ErrorItem(T), FUNC_NAME(cmp, Ord(ErrorItem(T))));         \
                                                                          \
   static inline bool FUNC_NAME(isUnknown,                                \
                                ErrorItem(T))(ErrorItem(T) e) {           \
@@ -105,9 +64,6 @@
     Maybe(ErrorItem(Token(S))) unexpected;                               \
     List(ErrorItem(Token(S))) expecting;                                 \
   };                                                                     \
-                                                                         \
-  trait_Eq(ParseError(S));                                               \
-  trait_Ord(ParseError(S));                                              \
                                                                          \
   C_API_END                                                              \
   END_OF_STATEMENTS

--- a/include/cparsec3/parsec/parser/ParsecChoice.h
+++ b/include/cparsec3/parsec/parser/ParsecChoice.h
@@ -10,8 +10,6 @@
 #define trait_ParsecChoice(S, T)                                         \
   C_API_BEGIN                                                            \
                                                                          \
-  trait_Eq(Parsec(S, T));                                                \
-  trait_Ord(Parsec(S, T));                                               \
   trait_Mem(Parsec(S, T));                                               \
   trait_Array(Parsec(S, T));                                             \
                                                                          \
@@ -31,20 +29,6 @@
 #define impl_ParsecChoice(S, T)                                          \
   C_API_BEGIN                                                            \
                                                                          \
-  static bool FUNC_NAME(eq, Eq(Parsec(S, T)))(Parsec(S, T) p1,           \
-                                              Parsec(S, T) p2) {         \
-    UNUSED(p1);                                                          \
-    UNUSED(p2);                                                          \
-    return true;                                                         \
-  }                                                                      \
-  static int FUNC_NAME(cmp, Ord(Parsec(S, T)))(Parsec(S, T) p1,          \
-                                               Parsec(S, T) p2) {        \
-    UNUSED(p1);                                                          \
-    UNUSED(p2);                                                          \
-    return 0;                                                            \
-  }                                                                      \
-  instance_Eq(Parsec(S, T), FUNC_NAME(eq, Eq(Parsec(S, T))));            \
-  instance_Ord(Parsec(S, T), FUNC_NAME(cmp, Ord(Parsec(S, T))));         \
   impl_Mem(Parsec(S, T));                                                \
   impl_Array(Parsec(S, T));                                              \
                                                                          \

--- a/src/cparsec3/base/eq.c
+++ b/src/cparsec3/base/eq.c
@@ -34,3 +34,13 @@ static bool EQ(String)(String a, String b) {
   return !strcmp(a, b);
 }
 instance_Eq(String, EQ(String));
+
+FOREACH(impl_Eq_Array, TYPESET(ALL));
+FOREACH(impl_Eq_List, TYPESET(ALL));
+FOREACH(impl_Eq_Maybe, TYPESET(ALL));
+
+#if defined(TYPESET_CONTAINER)
+FOREACH(impl_Eq_Array, TYPESET_CONTAINER);
+FOREACH(impl_Eq_List, TYPESET_CONTAINER);
+FOREACH(impl_Eq_Maybe, TYPESET_CONTAINER);
+#endif

--- a/src/cparsec3/base/ord.c
+++ b/src/cparsec3/base/ord.c
@@ -62,3 +62,13 @@ static int CMP(String)(String a, String b) {
   return (x <= 0 ? (x == 0 ? 0 : -1) : 1);
 }
 instance_Ord(String, CMP(String));
+
+FOREACH(impl_Ord_Array, TYPESET(ALL));
+FOREACH(impl_Ord_List, TYPESET(ALL));
+FOREACH(impl_Ord_Maybe, TYPESET(ALL));
+
+#if defined(TYPESET_CONTAINER)
+FOREACH(impl_Ord_Array, TYPESET_CONTAINER);
+FOREACH(impl_Ord_List, TYPESET_CONTAINER);
+FOREACH(impl_Ord_Maybe, TYPESET_CONTAINER);
+#endif

--- a/src/cparsec3/base/show.c
+++ b/src/cparsec3/base/show.c
@@ -104,7 +104,12 @@ static inline void TOSTRING(bool)(CharBuff* b, bool x) {
 instance_Show(bool, TOSTRING(bool));
 
 // -----------------------------------------------------------------------
-impl_ShowSeq(Array, char);
-impl_ShowSeq(List, char);
-impl_ShowSeq(Array, String);
-impl_ShowSeq(List, String);
+FOREACH(impl_Show_Array, TYPESET(ALL));
+FOREACH(impl_Show_List, TYPESET(ALL));
+FOREACH(impl_Show_Maybe, TYPESET(ALL));
+
+#if defined(TYPESET_CONTAINER)
+FOREACH(impl_Show_Array, TYPESET_CONTAINER);
+FOREACH(impl_Show_List, TYPESET_CONTAINER);
+FOREACH(impl_Show_Maybe, TYPESET_CONTAINER);
+#endif


### PR DESCRIPTION
Relaxed tight requirements of containers.
i.e. Detached `Eq`, `Ord`, and `Show` from default implementation of `Array`, `List`, and `Maybe`.