### PR TITLE
Refactor/ParseError(s)

### DIFF
--- a/include/cparsec3/parsec/parseerror.h
+++ b/include/cparsec3/parsec/parseerror.h
@@ -34,7 +34,7 @@
                                                                          \
   typedef struct ErrorItemT(S) ErrorItemT(S);                            \
   struct ErrorItemT(S) {                                                 \
-    bool (*isUnknown)(ErrorItem(S) e);                                   \
+    bool (*null)(ErrorItem(S) e);                                        \
     Hints(S) (*toHints)(Token(S) t);                                     \
     Hints(S) (*merge)(Hints(S) hs1, Hints(S) hs2);                       \
     void (*print)(ErrorItem(S) e);                                       \
@@ -51,8 +51,7 @@
   /* impl_Maybe(ErrorItem(S)); */                                        \
   impl_List(ErrorItem(S));                                               \
                                                                          \
-  static inline bool FUNC_NAME(isUnknown,                                \
-                               ErrorItem(S))(ErrorItem(S) e) {           \
+  static inline bool FUNC_NAME(null, ErrorItem(S))(ErrorItem(S) e) {     \
     switch (e.type) {                                                    \
     case LABEL:                                                          \
       return !e.label;                                                   \
@@ -115,7 +114,7 @@
                                                                          \
   ErrorItemT(S) Trait(ErrorItem(S)) {                                    \
     return (ErrorItemT(S)){                                              \
-        .isUnknown = FUNC_NAME(isUnknown, ErrorItem(S)),                 \
+        .null = FUNC_NAME(null, ErrorItem(S)),                           \
         .toHints = FUNC_NAME(toHints, Hints(S)),                         \
         .merge = FUNC_NAME(merge, Hints(S)),                             \
         .print = FUNC_NAME(print, ErrorItem(S)),                         \
@@ -144,7 +143,7 @@
                                                                          \
   typedef struct ParseErrorT(S) ParseErrorT(S);                          \
   struct ParseErrorT(S) {                                                \
-    bool (*isUnknown)(ParseError(S) e);                                  \
+    bool (*null)(ParseError(S) e);                                       \
     ParseError(S) (*merge)(ParseError(S) e1, ParseError(S) e2);          \
     void (*print)(ParseError(S) e);                                      \
   };                                                                     \
@@ -160,11 +159,10 @@
                                                                          \
   impl_ErrorItem(S);                                                     \
                                                                          \
-  static inline bool FUNC_NAME(isUnknown,                                \
-                               ParseError(S))(ParseError(S) e) {         \
+  static inline bool FUNC_NAME(null, ParseError(S))(ParseError(S) e) {   \
     ErrorItemT(S) EI = trait(ErrorItem(S));                              \
     ListT(ErrorItem(S)) L = trait(List(ErrorItem(S)));                   \
-    return ((e.unexpected.none || EI.isUnknown(e.unexpected.value)) &&   \
+    return ((e.unexpected.none || EI.null(e.unexpected.value)) &&        \
             L.null(e.expecting));                                        \
   }                                                                      \
                                                                          \
@@ -172,7 +170,7 @@
     ErrorItemT(S) EI = trait(ErrorItem(S));                              \
     ParseErrorT(S) E = trait(ParseError(S));                             \
     /* printf("error:%" PRIdMAX ":\n", e.offset); */                     \
-    if (E.isUnknown(e)) {                                                \
+    if (E.null(e)) {                                                     \
       printf("unknown error\n");                                         \
       return;                                                            \
     }                                                                    \
@@ -236,7 +234,7 @@
                                                                          \
   ParseErrorT(S) Trait(ParseError(S)) {                                  \
     return (ParseErrorT(S)){                                             \
-        .isUnknown = FUNC_NAME(isUnknown, ParseError(S)),                \
+        .null = FUNC_NAME(null, ParseError(S)),                          \
         .merge = FUNC_NAME(merge, ParseError(S)),                        \
         .print = FUNC_NAME(print, ParseError(S)),                        \
     };                                                                   \

--- a/include/cparsec3/parsec/parseerror.h
+++ b/include/cparsec3/parsec/parseerror.h
@@ -144,6 +144,13 @@
   typedef struct ParseErrorT(S) ParseErrorT(S);                          \
   struct ParseErrorT(S) {                                                \
     bool (*null)(ParseError(S) e);                                       \
+    ParseError(S) (*unexpected)(Offset o, ErrorItem(S) e, Hints(S) hs);  \
+    ParseError(S) (*unexpected_end_of_input)(Offset o, Hints(S) hs);     \
+    ParseError(S) (*unexpected_token)(Offset o, Token(S) t,              \
+                                      Hints(S) hs);                      \
+    ParseError(S) (*unexpected_tokens)(Offset o, Tokens(S) chk,          \
+                                       Hints(S) hs);                     \
+    ParseError(S) (*unexpected_label)(Offset o, String l, Hints(S) hs);  \
     ParseError(S) (*merge)(ParseError(S) e1, ParseError(S) e2);          \
     void (*print)(ParseError(S) e);                                      \
   };                                                                     \
@@ -164,6 +171,57 @@
     ListT(ErrorItem(S)) L = trait(List(ErrorItem(S)));                   \
     return ((e.unexpected.none || EI.null(e.unexpected.value)) &&        \
             L.null(e.expecting));                                        \
+  }                                                                      \
+                                                                         \
+  static inline ParseError(S) FUNC_NAME(unexpected, ParseError(S))(      \
+      Offset o, ErrorItem(S) i, Hints(S) hs) {                           \
+    return (ParseError(S)){                                              \
+        .offset = o,                                                     \
+        .unexpected.value = i,                                           \
+        .expecting = hs,                                                 \
+    };                                                                   \
+  }                                                                      \
+                                                                         \
+  static inline ParseError(S) FUNC_NAME(                                 \
+      unexpected_end_of_input, ParseError(S))(Offset o, Hints(S) hs) {   \
+    return (ParseError(S)){                                              \
+        .offset = o,                                                     \
+        .unexpected.value.type = END_OF_INPUT,                           \
+        .expecting = hs,                                                 \
+    };                                                                   \
+  }                                                                      \
+                                                                         \
+  static inline ParseError(S)                                            \
+      FUNC_NAME(unexpected_token, ParseError(S))(Offset o, Token(S) t,   \
+                                                 Hints(S) hs) {          \
+    return (ParseError(S)){                                              \
+        .offset = o,                                                     \
+        .unexpected.value.type = TOKENS,                                 \
+        .unexpected.value.tokens = trait(List(Token(S))).cons(t, NULL),  \
+        .expecting = hs,                                                 \
+    };                                                                   \
+  }                                                                      \
+                                                                         \
+  static inline ParseError(S)                                            \
+      FUNC_NAME(unexpected_tokens,                                       \
+                ParseError(S))(Offset o, Tokens(S) chk, Hints(S) hs) {   \
+    return (ParseError(S)){                                              \
+        .offset = o,                                                     \
+        .unexpected.value.type = TOKENS,                                 \
+        .unexpected.value.tokens = trait(Stream(S)).chunkToTokens(chk),  \
+        .expecting = hs,                                                 \
+    };                                                                   \
+  }                                                                      \
+                                                                         \
+  static inline ParseError(S)                                            \
+      FUNC_NAME(unexpected_label, ParseError(S))(Offset o, String l,     \
+                                                 Hints(S) hs) {          \
+    return (ParseError(S)){                                              \
+        .offset = o,                                                     \
+        .unexpected.value.type = LABEL,                                  \
+        .unexpected.value.label = l,                                     \
+        .expecting = hs,                                                 \
+    };                                                                   \
   }                                                                      \
                                                                          \
   static inline void FUNC_NAME(print, ParseError(S))(ParseError(S) e) {  \
@@ -235,6 +293,13 @@
   ParseErrorT(S) Trait(ParseError(S)) {                                  \
     return (ParseErrorT(S)){                                             \
         .null = FUNC_NAME(null, ParseError(S)),                          \
+        .unexpected = FUNC_NAME(unexpected, ParseError(S)),              \
+        .unexpected_end_of_input =                                       \
+            FUNC_NAME(unexpected_end_of_input, ParseError(S)),           \
+        .unexpected_token = FUNC_NAME(unexpected_token, ParseError(S)),  \
+        .unexpected_tokens =                                             \
+            FUNC_NAME(unexpected_tokens, ParseError(S)),                 \
+        .unexpected_label = FUNC_NAME(unexpected_label, ParseError(S)),  \
         .merge = FUNC_NAME(merge, ParseError(S)),                        \
         .print = FUNC_NAME(print, ParseError(S)),                        \
     };                                                                   \

--- a/include/cparsec3/parsec/parser/ParsecChoice.h
+++ b/include/cparsec3/parsec/parser/ParsecChoice.h
@@ -106,7 +106,7 @@
      ContErrArgs(S, T) /* error -> state -> reply */                     \
   ) {                                                                    \
     g_bind((err, e1, s1, e2, s2), *args);                                \
-    ParseError(S) e = FUNC_NAME(merge, ParseError(S))(e1, e2);           \
+    ParseError(S) e = trait(ParseError(S)).merge(e1, e2);                \
     Stream(S) SS = trait(Stream(S));                                     \
     S s = (SS.offsetOf(s1) > SS.offsetOf(s2) ? s1 : s2);                 \
     return fn_apply(err, e, s);                                          \

--- a/include/cparsec3/parsec/parser/ParsecToken.h
+++ b/include/cparsec3/parsec/parser/ParsecToken.h
@@ -52,24 +52,18 @@
     Stream(S) SS = trait(Stream(S));                                     \
     __auto_type maybe = SS.take1(s);                                     \
     if (maybe.none) {                                                    \
-      ParseError(S) e = {                                                \
-          .offset = SS.offsetOf(s),                                      \
-          .unexpected.value.type = END_OF_INPUT,                         \
-          .expecting = expect,                                           \
-      };                                                                 \
+      Offset o = SS.offsetOf(s);                                         \
+      ParseErrorT(S) E = trait(ParseError(S));                           \
+      ParseError(S) e = E.unexpected_end_of_input(o, expect);            \
       return fn_apply(eerr, e, s);                                       \
     }                                                                    \
                                                                          \
     Token(S) a = maybe.value.e1;                                         \
     __auto_type maybe2 = fn_apply(testToken, a);                         \
     if (maybe2.none) {                                                   \
-      ParseError(S) e = {                                                \
-          .offset = SS.offsetOf(s),                                      \
-          .unexpected.value.type = TOKENS,                               \
-          .unexpected.value.tokens =                                     \
-              trait(List(Token(S))).cons(a, NULL),                       \
-          .expecting = expect,                                           \
-      };                                                                 \
+      Offset o = SS.offsetOf(s);                                         \
+      ParseErrorT(S) E = trait(ParseError(S));                           \
+      ParseError(S) e = E.unexpected_token(o, a, expect);                \
       return fn_apply(eerr, e, s);                                       \
     }                                                                    \
                                                                          \

--- a/include/cparsec3/parsec/parser/ParsecToken1.h
+++ b/include/cparsec3/parsec/parser/ParsecToken1.h
@@ -92,21 +92,16 @@
     int n = IS.chunkLength(pattern);                                     \
     __auto_type maybe = IS.takeN(n, s);                                  \
     if (maybe.none) {                                                    \
-      ParseError(S) e = {                                                \
-          .offset = IS.offsetOf(s),                                      \
-          .unexpected.value.type = END_OF_INPUT,                         \
-          .expecting = NULL,                                             \
-      };                                                                 \
+      Offset o = IS.offsetOf(s);                                         \
+      ParseErrorT(S) E = trait(ParseError(S));                           \
+      ParseError(S) e = E.unexpected_end_of_input(o, NULL);              \
       return fn_apply(eerr, e, s);                                       \
     }                                                                    \
     Tokens(S) actual = maybe.value.e1;                                   \
     if (!fn_apply(test, pattern, actual)) {                              \
-      ParseError(S) e = {                                                \
-          .offset = IS.offsetOf(s),                                      \
-          .unexpected.value = {.type = TOKENS,                           \
-                               .tokens = IS.chunkToTokens(actual)},      \
-          .expecting = NULL,                                             \
-      };                                                                 \
+      Offset o = IS.offsetOf(s);                                         \
+      ParseErrorT(S) E = trait(ParseError(S));                           \
+      ParseError(S) e = E.unexpected_tokens(o, actual, NULL);            \
       return fn_apply(eerr, e, s);                                       \
     }                                                                    \
     int m = IS.chunkLength(actual);                                      \


### PR DESCRIPTION
renamed:
- trait(ErrorItem(S)).isUnknown(item)` -> `trait(ErrorItem(S)).null(item)`
- trait(ParseError(S)).isUnknown(e)` -> `trait(ParseError(S)).null(e)`

added:
- `trait(ParseError(S)).unexpected(offset, item, hints)`
- `trait(ParseError(S)).unexpected_end_of_input(offset, hints)`
- `trait(ParseError(S)).unexpected_token(offset, token, hints)`
- `trait(ParseError(S)).unexpected_tokens(offset, chunk, hints)`
- `trait(ParseError(S)).unexpected_label(offset, label, hints)`
