### PR TITLE
Parsec/user-defined-return-types

### DIFF
--- a/include/cparsec3/base/internal/function.h
+++ b/include/cparsec3/base/internal/function.h
@@ -13,9 +13,59 @@
 // -----------------------------------------------------------------------
 #undef fn_apply
 #define fn_apply(...) fn_apply0(__VA_ARGS__)
+
 #define fn_apply0(f, ...)                                                \
-  FOLDL(fn_apply1, (f), BIND(((f).args), __VA_ARGS__))
-#define fn_apply1(f, ax) f.apply ax
+  CAT(fn_apply, VARIADIC_SIZE(__VA_ARGS__))(f, __VA_ARGS__)
+
+#define fn_apply1(f, x1) f.apply(f.args, x1)
+#define fn_apply2(f, x1, x2) f.apply(f.args, x1).apply(f.args, x2)
+#define fn_apply3(f, x1, x2, x3)                                         \
+  f.apply(f.args, x1).apply(f.args, x2).apply(f.args, x3)
+#define fn_apply4(f, x1, x2, x3, x4)                                     \
+  f.apply(f.args, x1)                                                    \
+      .apply(f.args, x2)                                                 \
+      .apply(f.args, x3)                                                 \
+      .apply(f.args, x4)
+#define fn_apply5(f, x1, x2, x3, x4, x5)                                 \
+  f.apply(f.args, x1)                                                    \
+      .apply(f.args, x2)                                                 \
+      .apply(f.args, x3)                                                 \
+      .apply(f.args, x4)                                                 \
+      .apply(f.args, x5)
+#define fn_apply6(f, x1, x2, x3, x4, x5, x6)                             \
+  f.apply(f.args, x1)                                                    \
+      .apply(f.args, x2)                                                 \
+      .apply(f.args, x3)                                                 \
+      .apply(f.args, x4)                                                 \
+      .apply(f.args, x5)                                                 \
+      .apply(f.args, x6)
+#define fn_apply7(f, x1, x2, x3, x4, x5, x6, x7)                         \
+  f.apply(f.args, x1)                                                    \
+      .apply(f.args, x2)                                                 \
+      .apply(f.args, x3)                                                 \
+      .apply(f.args, x4)                                                 \
+      .apply(f.args, x5)                                                 \
+      .apply(f.args, x6)                                                 \
+      .apply(f.args, x7)
+#define fn_apply8(f, x1, x2, x3, x4, x5, x6, x7, x8)                     \
+  f.apply(f.args, x1)                                                    \
+      .apply(f.args, x2)                                                 \
+      .apply(f.args, x3)                                                 \
+      .apply(f.args, x4)                                                 \
+      .apply(f.args, x5)                                                 \
+      .apply(f.args, x6)                                                 \
+      .apply(f.args, x7)                                                 \
+      .apply(f.args, x8)
+#define fn_apply9(f, x1, x2, x3, x4, x5, x6, x7, x8, x9)                 \
+  f.apply(f.args, x1)                                                    \
+      .apply(f.args, x2)                                                 \
+      .apply(f.args, x3)                                                 \
+      .apply(f.args, x4)                                                 \
+      .apply(f.args, x5)                                                 \
+      .apply(f.args, x6)                                                 \
+      .apply(f.args, x7)                                                 \
+      .apply(f.args, x8)                                                 \
+      .apply(f.args, x9)
 
 // -----------------------------------------------------------------------
 #undef typedef_Fn

--- a/include/cparsec3/easy_parsec/parser/choice.h
+++ b/include/cparsec3/easy_parsec/parser/choice.h
@@ -20,19 +20,10 @@
 #define choice(...) FOLDL(either, __VA_ARGS__)
 
 // -----------------------------------------------------------------------
-trait_ParsecChoice(CPARSEC_STREAM_TYPE, None);
-trait_ParsecChoice(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-trait_ParsecChoice(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-trait_ParsecChoice(CPARSEC_STREAM_TYPE,
-                   Array(Token(CPARSEC_STREAM_TYPE)));
-trait_ParsecChoice(CPARSEC_STREAM_TYPE,
-                   Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(trait_ParsecChoice, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 
 #ifdef CPARSEC_CONFIG_IMPLEMENT
-impl_ParsecChoice(CPARSEC_STREAM_TYPE, None);
-impl_ParsecChoice(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-impl_ParsecChoice(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-impl_ParsecChoice(CPARSEC_STREAM_TYPE, Array(Token(CPARSEC_STREAM_TYPE)));
-impl_ParsecChoice(CPARSEC_STREAM_TYPE,
-                  Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(impl_ParsecChoice, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 #endif

--- a/include/cparsec3/easy_parsec/parser/combinator.h
+++ b/include/cparsec3/easy_parsec/parser/combinator.h
@@ -24,20 +24,10 @@
   GENERIC_PARSECCOMBINATOR(CPARSEC_STREAM_TYPE, p).pNotFollowedBy(p)
 
 // -----------------------------------------------------------------------
-trait_ParsecCombinator(CPARSEC_STREAM_TYPE, None);
-trait_ParsecCombinator(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-trait_ParsecCombinator(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-trait_ParsecCombinator(CPARSEC_STREAM_TYPE,
-                       Array(Token(CPARSEC_STREAM_TYPE)));
-trait_ParsecCombinator(CPARSEC_STREAM_TYPE,
-                       Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(trait_ParsecCombinator, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 
 #ifdef CPARSEC_CONFIG_IMPLEMENT
-impl_ParsecCombinator(CPARSEC_STREAM_TYPE, None);
-impl_ParsecCombinator(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-impl_ParsecCombinator(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-impl_ParsecCombinator(CPARSEC_STREAM_TYPE,
-                      Array(Token(CPARSEC_STREAM_TYPE)));
-impl_ParsecCombinator(CPARSEC_STREAM_TYPE,
-                      Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(impl_ParsecCombinator, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 #endif

--- a/include/cparsec3/easy_parsec/parser/failure.h
+++ b/include/cparsec3/easy_parsec/parser/failure.h
@@ -17,20 +17,10 @@
   TRAIT_PARSECFAILURE(CPARSEC_STREAM_TYPE, T).pUnexpected(item)
 
 // -----------------------------------------------------------------------
-trait_ParsecFailure(CPARSEC_STREAM_TYPE, None);
-trait_ParsecFailure(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-trait_ParsecFailure(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-trait_ParsecFailure(CPARSEC_STREAM_TYPE,
-                    Array(Token(CPARSEC_STREAM_TYPE)));
-trait_ParsecFailure(CPARSEC_STREAM_TYPE,
-                    Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(trait_ParsecFailure, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 
 #ifdef CPARSEC_CONFIG_IMPLEMENT
-impl_ParsecFailure(CPARSEC_STREAM_TYPE, None);
-impl_ParsecFailure(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-impl_ParsecFailure(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-impl_ParsecFailure(CPARSEC_STREAM_TYPE,
-                   Array(Token(CPARSEC_STREAM_TYPE)));
-impl_ParsecFailure(CPARSEC_STREAM_TYPE,
-                   Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(impl_ParsecFailure, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 #endif

--- a/include/cparsec3/easy_parsec/parser/repeat.h
+++ b/include/cparsec3/easy_parsec/parser/repeat.h
@@ -22,10 +22,10 @@
   GENERIC_PARSECREPEAT(CPARSEC_STREAM_TYPE, p).pCount_min_max(m, n, p)
 
 // -----------------------------------------------------------------------
-trait_ParsecRepeat(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-trait_ParsecRepeat(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
+BIND_FOR(trait_ParsecRepeat, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES_0(CPARSEC_STREAM_TYPE));
 
 #ifdef CPARSEC_CONFIG_IMPLEMENT
-impl_ParsecRepeat(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-impl_ParsecRepeat(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
+BIND_FOR(impl_ParsecRepeat, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES_0(CPARSEC_STREAM_TYPE));
 #endif

--- a/include/cparsec3/easy_parsec/parser/token.h
+++ b/include/cparsec3/easy_parsec/parser/token.h
@@ -40,18 +40,11 @@
 
 // -----------------------------------------------------------------------
 trait_ParsecToken1(CPARSEC_STREAM_TYPE);
-trait_ParsecToken(CPARSEC_STREAM_TYPE, None);
-trait_ParsecToken(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-trait_ParsecToken(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-trait_ParsecToken(CPARSEC_STREAM_TYPE, Array(Token(CPARSEC_STREAM_TYPE)));
-trait_ParsecToken(CPARSEC_STREAM_TYPE,
-                  Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(trait_ParsecToken, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 
 #ifdef CPARSEC_CONFIG_IMPLEMENT
 impl_ParsecToken1(CPARSEC_STREAM_TYPE);
-impl_ParsecToken(CPARSEC_STREAM_TYPE, None);
-impl_ParsecToken(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-impl_ParsecToken(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-impl_ParsecToken(CPARSEC_STREAM_TYPE, Array(Token(CPARSEC_STREAM_TYPE)));
-impl_ParsecToken(CPARSEC_STREAM_TYPE, Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(impl_ParsecToken, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 #endif

--- a/include/cparsec3/easy_parsec/runner.h
+++ b/include/cparsec3/easy_parsec/runner.h
@@ -53,11 +53,16 @@ BIND_FOR(impl_ParsecRunner, CPARSEC_STREAM_TYPE,
 
 #define SCAN1(_p_)                                                       \
   __auto_type TMPID = runParsec(_p_, _s_);                               \
-  if (!TMPID.result.success) {                                           \
-    __auto_type _err_ = (TMPID.consumed ? _cerr_ : _eerr_);              \
-    return fn_apply(_err_, TMPID.result.err, TMPID.result.state);        \
-  }                                                                      \
-  _s_ = TMPID.result.state;
+  _s_ = TMPID.result.state;                                              \
+  do {                                                                   \
+    if (!TMPID.result.success) {                                         \
+      Stream(CPARSEC_STREAM_TYPE) SS =                                   \
+          trait(Stream(CPARSEC_STREAM_TYPE));                            \
+      __auto_type _err_ =                                                \
+          (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cerr_ : _eerr_);      \
+      return fn_apply(_err_, TMPID.result.err, _s_);                     \
+    }                                                                    \
+  } while (0)
 
 #define SCAN2(_p_, _x_)                                                  \
   SCAN1(_p_);                                                            \

--- a/include/cparsec3/easy_parsec/runner.h
+++ b/include/cparsec3/easy_parsec/runner.h
@@ -63,6 +63,18 @@ BIND_FOR(impl_ParsecRunner, CPARSEC_STREAM_TYPE,
   SCAN1(_p_);                                                            \
   __auto_type _x_ = TMPID.result.ok;
 
+#define FAIL(_msg_)                                                      \
+  do {                                                                   \
+    Stream(CPARSEC_STREAM_TYPE) SS = trait(Stream(CPARSEC_STREAM_TYPE)); \
+    __auto_type _err_ =                                                  \
+        (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cerr_ : _eerr_);        \
+    Hints(CPARSEC_STREAM_TYPE) empty_hints = {0};                        \
+    ParseError(CPARSEC_STREAM_TYPE) e =                                  \
+        trait(ParseError(CPARSEC_STREAM_TYPE))                           \
+            .unexpected_label(SS.offsetOf(_s_), _msg_, empty_hints);     \
+    return fn_apply(_err_, e, _s_);                                      \
+  } while (0)
+
 #define RETURN(_x_)                                                      \
   do {                                                                   \
     Stream(CPARSEC_STREAM_TYPE) SS = trait(Stream(CPARSEC_STREAM_TYPE)); \

--- a/include/cparsec3/easy_parsec/runner.h
+++ b/include/cparsec3/easy_parsec/runner.h
@@ -31,22 +31,13 @@
 
 // -----------------------------------------------------------------------
 trait_ParseError(CPARSEC_STREAM_TYPE);
-trait_ParsecRunner(CPARSEC_STREAM_TYPE, None);
-trait_ParsecRunner(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-trait_ParsecRunner(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-trait_ParsecRunner(CPARSEC_STREAM_TYPE,
-                   Array(Token(CPARSEC_STREAM_TYPE)));
-trait_ParsecRunner(CPARSEC_STREAM_TYPE,
-                   Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(trait_ParsecRunner, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 
 #ifdef CPARSEC_CONFIG_IMPLEMENT
 impl_ParseError(CPARSEC_STREAM_TYPE);
-impl_ParsecRunner(CPARSEC_STREAM_TYPE, None);
-impl_ParsecRunner(CPARSEC_STREAM_TYPE, Token(CPARSEC_STREAM_TYPE));
-impl_ParsecRunner(CPARSEC_STREAM_TYPE, Tokens(CPARSEC_STREAM_TYPE));
-impl_ParsecRunner(CPARSEC_STREAM_TYPE, Array(Token(CPARSEC_STREAM_TYPE)));
-impl_ParsecRunner(CPARSEC_STREAM_TYPE,
-                  Array(Tokens(CPARSEC_STREAM_TYPE)));
+BIND_FOR(impl_ParsecRunner, CPARSEC_STREAM_TYPE,
+         PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 #endif
 
 // -----------------------------------------------------------------------

--- a/include/cparsec3/easy_parsec/types.h
+++ b/include/cparsec3/easy_parsec/types.h
@@ -2,6 +2,13 @@
 #pragma once
 
 #define PARSER_RETURN_TYPES(S)                                           \
-  None, PARSER_RETURN_TYPES_0(S), PARSER_RETURN_TYPES_1(S)
-#define PARSER_RETURN_TYPES_0(S) Token(S), Tokens(S)
-#define PARSER_RETURN_TYPES_1(S) APPLY(Array, PARSER_RETURN_TYPES_0(S))
+  None, PARSER_RETURN_TYPES_0(S), APPLY(Array, PARSER_RETURN_TYPES_0(S))
+
+#define PARSER_RETURN_TYPES_0(S)                                         \
+  SQUASH(Token(S), Tokens(S), CPARSEC_USER_TYPES())
+
+#ifndef CPARSEC_CONFIG_USER_TYPES
+#define CPARSEC_USER_TYPES()
+#else
+#define CPARSEC_USER_TYPES() CPARSEC_CONFIG_USER_TYPES
+#endif


### PR DESCRIPTION
It is now possible to use a non-default parser type by defining `CPARSEC_CONFIG_USER_TYPES`.

~~~
// define `CPARSEC_CONFIG_USER_TYPES` ahead of any `#include`
#define CPARSEC_CONFIG_USER_TYPES int, uint64_t

#include <cparsec3/easy_parsec/parser/choice.h>
...
// In this case, the following additional parser types are available.
// `Parsec(CPARSEC_STREAM_TYPE, int)`
// `Parsec(CPARSEC_STREAM_TYPE, uint64_t)`
~~~
