### PR TITLE
parsec macro

### DIFF
--- a/example/parsec/src/parsec.c
+++ b/example/parsec/src/parsec.c
@@ -20,7 +20,8 @@
 #include <limits.h>
 
 // -----------------------------------------------------------------------
-fn(numberFn, UnParserArgs(S, int)) {
+// PARSER(int) number0(void);
+parsec(number0, int) {
   DO() {
     SCAN(some(digit()), xs);
     ArrayT(char) A = trait(Array(char));
@@ -36,13 +37,13 @@ fn(numberFn, UnParserArgs(S, int)) {
   }
 }
 
-Parsec(S, int) number(void) {
-  Parsec(S, int) p = {numberFn()};
-  return label("a number [0..INT_MAX]", tryp(p));
+PARSER(int) number(void) {
+  return label("a number [0..INT_MAX]", tryp(number0()));
 }
 
 // -----------------------------------------------------------------------
-fn(abcFn, UnParserArgs(S, Array(char))) {
+// PARSER(Array(char)) abc(void);
+parsec(abc, Array(char)) {
   DO() {
     SCAN(char1('a'), a);
     SCAN(char1('b'), b);
@@ -51,12 +52,9 @@ fn(abcFn, UnParserArgs(S, Array(char))) {
   }
 }
 
-Parsec(S, Array(char)) abc(void) {
-  return (Parsec(S, Array(char))){abcFn()};
-}
-
 // -----------------------------------------------------------------------
-fn(identifierImpl, UnParserArgs(S, String)) {
+// PARSER(String) identifier0(void);
+parsec(identifier0, String) {
   __auto_type identStart = either(char1('_'), letter());
   __auto_type identLetter = many(either(char1('_'), alphaNum()));
   __auto_type spaces = many(whitespace());
@@ -75,14 +73,14 @@ fn(identifierImpl, UnParserArgs(S, String)) {
   }
 }
 
-Parsec(S, String) identifier(void) {
-  Parsec(S, String) p = {identifierImpl()};
-  return label("identifier", p);
+PARSER(String) identifier(void) {
+  return label("identifier", identifier0());
 }
 
 // -----------------------------------------------------------------------
-typedef_Fn(Token(S), UnParser(S, None));
-fn(fail_on_Fn, Token(S), UnParserArgs(S, None)) {
+// PARSER(None) fail_on(Token(S) c);
+typedef_FnParser(Token(S), None);
+parsec(fail_on, Token(S), None) {
   DO_WITH(c) {
     __auto_type p = anySingleBut(c);
     for (;;) {
@@ -90,12 +88,6 @@ fn(fail_on_Fn, Token(S), UnParserArgs(S, None)) {
     }
     RETURN((None){0});
   }
-}
-
-Parsec(S, None) fail_on(Token(S) c) {
-  __auto_type f = fail_on_Fn();
-  Parsec(S, None) p = {fn_apply(f, c)};
-  return p;
 }
 
 // -----------------------------------------------------------------------

--- a/example/parsec/src/parsec.c
+++ b/example/parsec/src/parsec.c
@@ -79,9 +79,8 @@ PARSER(String) identifier(void) {
 
 // -----------------------------------------------------------------------
 // PARSER(None) fail_on(Token(S) c);
-typedef_FnParser(Token(S), None);
 parsec(fail_on, Token(S), None) {
-  DO_WITH(c) {
+  DO() WITH(c) {
     __auto_type p = anySingleBut(c);
     for (;;) {
       SCAN(p);

--- a/include/cparsec3/base/base_generics.h
+++ b/include/cparsec3/base/base_generics.h
@@ -112,10 +112,11 @@
 // ---- Structured bindings
 #define g_bind(x, t) g_bind_I(t, DISCLOSE(x))
 #define g_bind_I(t, ...)                                                 \
-  FOREACH(EXPAND, SQUASH(APPLY(g_bind0, (TMPID, t),                      \
-                               CAT(g_bind, VARIADIC_SIZE(__VA_ARGS__))(  \
-                                   TMPID, __VA_ARGS__))))
-#define g_bind0(var_, val_) IF(IS_NULL(var_))(, __auto_type var_ = val_)
+  FOREACH(EXPAND,                                                        \
+          SQUASH(APPLY(g_bind0, CAT(g_bind, VARIADIC_SIZE(__VA_ARGS__))( \
+                                    (t), __VA_ARGS__))))
+#define g_bind0(var_, val_)                                              \
+  IF(IS_NULL(var_))(, __auto_type var_ __attribute__((unused)) = val_)
 // clang-format off
 #define g_bind1(t, _1)                                                   \
   (_1, t.e1)

--- a/include/cparsec3/easy_parsec/def_parsec.h
+++ b/include/cparsec3/easy_parsec/def_parsec.h
@@ -1,0 +1,110 @@
+/* -*- coding: utf-8-unix -*- */
+#pragma once
+
+// -----------------------------------------------------------------------
+#define PARSER(R) Parsec(CPARSEC_STREAM_TYPE, R)
+#define FnParser(R) UnParser(CPARSEC_STREAM_TYPE, R)
+#define FnParserArgs(R) UnParserArgs(CPARSEC_STREAM_TYPE, R)
+
+#define PARAM(...) TYPE_NAME(PARAM, __VA_ARGS__)
+
+#define parsec(name, ...)                                                \
+  CAT(parsec, VARIADIC_SIZE(__VA_ARGS__))(name, __VA_ARGS__)
+
+#define parsec1(name, R)                                                 \
+  typedef None PARAM(name);                                              \
+  typedef_Fn(PARAM(name), FnParser(R));                                  \
+  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
+  PARSER(R) name(void) {                                                 \
+    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
+    return (PARSER(R)){fn_apply(f, (PARAM(name)){0})};                   \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
+
+#define parsec2(name, T1, R)                                             \
+  typedef struct {                                                       \
+    T1 e1;                                                               \
+  } PARAM(name);                                                         \
+  typedef_Fn(PARAM(name), FnParser(R));                                  \
+  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
+  PARSER(R) name(T1 x1) {                                                \
+    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
+    return (PARSER(R)){fn_apply(f, (PARAM(name)){x1})};                  \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
+
+#define parsec3(name, T1, T2, R)                                         \
+  typedef struct {                                                       \
+    T1 e1;                                                               \
+    T2 e2;                                                               \
+  } PARAM(name);                                                         \
+  typedef_Fn(PARAM(name), FnParser(R));                                  \
+  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
+  PARSER(R) name(T1 x1, T2 x2) {                                         \
+    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
+    return (PARSER(R)){fn_apply(f, (PARAM(name)){x1, x2})};              \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
+
+#define parsec4(name, T1, T2, T3, R)                                     \
+  typedef struct {                                                       \
+    T1 e1;                                                               \
+    T2 e2;                                                               \
+    T3 e3;                                                               \
+  } PARAM(name);                                                         \
+  typedef_Fn(PARAM(name), FnParser(R));                                  \
+  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
+  PARSER(R) name(T1 x1, T2 x2, T3 x3) {                                  \
+    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
+    return (PARSER(R)){fn_apply(f, (PARAM(name)){x1, x2, x3})};          \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
+
+// -----------------------------------------------------------------------
+#define DO()                                                             \
+  g_bind((_par_, _s0_, _cok_, _cerr_, _eok_, _eerr_), *args);            \
+  __auto_type _s_ = _s0_;
+
+#define WITH(...) g_bind((__VA_ARGS__), _par_);
+
+#define DO_WITH(...) DO() WITH(__VA_ARGS__)
+
+#define SCAN(...) CAT(SCAN, VARIADIC_SIZE(__VA_ARGS__))(__VA_ARGS__)
+
+#define SCAN1(_p_)                                                       \
+  __auto_type TMPID = runParsec(_p_, _s_);                               \
+  _s_ = TMPID.result.state;                                              \
+  do {                                                                   \
+    if (!TMPID.result.success) {                                         \
+      Stream(CPARSEC_STREAM_TYPE) SS =                                   \
+          trait(Stream(CPARSEC_STREAM_TYPE));                            \
+      __auto_type _err_ =                                                \
+          (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cerr_ : _eerr_);      \
+      return fn_apply(_err_, TMPID.result.err, _s_);                     \
+    }                                                                    \
+  } while (0)
+
+#define SCAN2(_p_, _x_)                                                  \
+  SCAN1(_p_);                                                            \
+  __auto_type _x_ = TMPID.result.ok;
+
+#define FAIL(_msg_)                                                      \
+  do {                                                                   \
+    Stream(CPARSEC_STREAM_TYPE) SS = trait(Stream(CPARSEC_STREAM_TYPE)); \
+    __auto_type _err_ =                                                  \
+        (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cerr_ : _eerr_);        \
+    Hints(CPARSEC_STREAM_TYPE) empty_hints = {0};                        \
+    ParseError(CPARSEC_STREAM_TYPE) e =                                  \
+        trait(ParseError(CPARSEC_STREAM_TYPE))                           \
+            .unexpected_label(SS.offsetOf(_s_), _msg_, empty_hints);     \
+    return fn_apply(_err_, e, _s_);                                      \
+  } while (0)
+
+#define RETURN(_x_)                                                      \
+  do {                                                                   \
+    Stream(CPARSEC_STREAM_TYPE) SS = trait(Stream(CPARSEC_STREAM_TYPE)); \
+    __auto_type _ok_ =                                                   \
+        (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cok_ : _eok_);          \
+    Hints(CPARSEC_STREAM_TYPE) empty_hints = {0};                        \
+    return fn_apply(_ok_, _x_, _s_, empty_hints);                        \
+  } while (0)

--- a/include/cparsec3/easy_parsec/runner.h
+++ b/include/cparsec3/easy_parsec/runner.h
@@ -41,6 +41,56 @@ BIND_FOR(impl_ParsecRunner, CPARSEC_STREAM_TYPE,
 #endif
 
 // -----------------------------------------------------------------------
+#define PARSER(R) Parsec(CPARSEC_STREAM_TYPE, R)
+#define FnParser(R) UnParser(CPARSEC_STREAM_TYPE, R)
+#define FnParserArgs(R) UnParserArgs(CPARSEC_STREAM_TYPE, R)
+
+#define typedef_FnParser(...)                                            \
+  CAT(typedef_FnParser, VARIADIC_SIZE(__VA_ARGS__))(__VA_ARGS__)
+
+#define typedef_FnParser1(R) typedef_Fn(FnParser(R))
+#define typedef_FnParser2(T1, R) typedef_Fn(T1, FnParser(R))
+#define typedef_FnParser3(T1, T2, R) typedef_Fn(T1, T2, FnParser(R))
+#define typedef_FnParser4(T1, T2, T3, R)                                 \
+  typedef_Fn(T1, T2, T3, FnParser(R))
+
+#define parsec(name, ...)                                                \
+  CAT(parsec, VARIADIC_SIZE(__VA_ARGS__))(name, __VA_ARGS__)
+
+#define parsec1(name, R)                                                 \
+  static FnParser(R) FUNC_NAME(name, PARSER(R))(void);                   \
+  PARSER(R) name(void) {                                                 \
+    return (PARSER(R)){                                                  \
+        FUNC_NAME(name, PARSER(R))(),                                    \
+    };                                                                   \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), FnParserArgs(R))
+
+#define parsec2(name, T1, R)                                             \
+  static Fn(T1, FnParser(R)) FUNC_NAME(name, PARSER(R))(void);           \
+  PARSER(R) name(T1 x1) {                                                \
+    Fn(T1, FnParser(R)) f = FUNC_NAME(name, PARSER(R))();                \
+    return (PARSER(R)){fn_apply(f, x1)};                                 \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), T1, FnParserArgs(R))
+
+#define parsec3(name, T1, T2, R)                                         \
+  static Fn(T1, T2, FnParser(R)) FUNC_NAME(name, PARSER(R))(void);       \
+  PARSER(R) name(T1 x1, T2 x2) {                                         \
+    Fn(T1, T2, FnParser(R)) f = FUNC_NAME(name, PARSER(R))();            \
+    return (PARSER(R)){fn_apply(f, x1, x2)};                             \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), T1, T2, FnParserArgs(R))
+
+#define parsec4(name, T1, T2, T3, R)                                     \
+  static Fn(T1, T2, T3, FnParser(R)) FUNC_NAME(name, PARSER(R))(void);   \
+  PARSER(R) name(T1 x1, T2 x2, T3 x3) {                                  \
+    Fn(T1, T2, T3, FnParser(R)) f = FUNC_NAME(name, PARSER(R))();        \
+    return (PARSER(R)){fn_apply(f, x1, x2, x3)};                         \
+  }                                                                      \
+  fn(FUNC_NAME(name, PARSER(R)), T1, T2, T3, FnParserArgs(R))
+
+// -----------------------------------------------------------------------
 #define DO()                                                             \
   g_bind((_s0_, _cok_, _cerr_, _eok_, _eerr_), *args);                   \
   __auto_type _s_ = _s0_;

--- a/include/cparsec3/easy_parsec/runner.h
+++ b/include/cparsec3/easy_parsec/runner.h
@@ -5,6 +5,7 @@
 
 #include "config.h"
 #include "types.h"
+#include "def_parsec.h"
 
 #include "../parsec/parsec.h"
 #include "../parsec/stream.h"
@@ -39,111 +40,3 @@ impl_ParseError(CPARSEC_STREAM_TYPE);
 BIND_FOR(impl_ParsecRunner, CPARSEC_STREAM_TYPE,
          PARSER_RETURN_TYPES(CPARSEC_STREAM_TYPE));
 #endif
-
-// -----------------------------------------------------------------------
-#define PARSER(R) Parsec(CPARSEC_STREAM_TYPE, R)
-#define FnParser(R) UnParser(CPARSEC_STREAM_TYPE, R)
-#define FnParserArgs(R) UnParserArgs(CPARSEC_STREAM_TYPE, R)
-
-#define PARAM(...) TYPE_NAME(PARAM, __VA_ARGS__)
-
-#define parsec(name, ...)                                                \
-  CAT(parsec, VARIADIC_SIZE(__VA_ARGS__))(name, __VA_ARGS__)
-
-#define parsec1(name, R)                                                 \
-  typedef None PARAM(name);                                              \
-  typedef_Fn(PARAM(name), FnParser(R));                                  \
-  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
-  PARSER(R) name(void) {                                                 \
-    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
-    return (PARSER(R)){fn_apply(f, (PARAM(name)){0})};                   \
-  }                                                                      \
-  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
-
-#define parsec2(name, T1, R)                                             \
-  typedef struct {                                                       \
-    T1 e1;                                                               \
-  } PARAM(name);                                                         \
-  typedef_Fn(PARAM(name), FnParser(R));                                  \
-  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
-  PARSER(R) name(T1 x1) {                                                \
-    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
-    return (PARSER(R)){fn_apply(f, (PARAM(name)){x1})};                  \
-  }                                                                      \
-  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
-
-#define parsec3(name, T1, T2, R)                                         \
-  typedef struct {                                                       \
-    T1 e1;                                                               \
-    T2 e2;                                                               \
-  } PARAM(name);                                                         \
-  typedef_Fn(PARAM(name), FnParser(R));                                  \
-  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
-  PARSER(R) name(T1 x1, T2 x2) {                                         \
-    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
-    return (PARSER(R)){fn_apply(f, (PARAM(name)){x1, x2})};              \
-  }                                                                      \
-  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
-
-#define parsec4(name, T1, T2, T3, R)                                     \
-  typedef struct {                                                       \
-    T1 e1;                                                               \
-    T2 e2;                                                               \
-    T3 e3;                                                               \
-  } PARAM(name);                                                         \
-  typedef_Fn(PARAM(name), FnParser(R));                                  \
-  static Fn(PARAM(name), FnParser(R)) FUNC_NAME(name, PARSER(R))(void);  \
-  PARSER(R) name(T1 x1, T2 x2, T3 x3) {                                  \
-    Fn(PARAM(name), FnParser(R)) f = FUNC_NAME(name, PARSER(R))();       \
-    return (PARSER(R)){fn_apply(f, (PARAM(name)){x1, x2, x3})};          \
-  }                                                                      \
-  fn(FUNC_NAME(name, PARSER(R)), PARAM(name), FnParserArgs(R))
-
-// -----------------------------------------------------------------------
-#define DO()                                                             \
-  g_bind((_par_, _s0_, _cok_, _cerr_, _eok_, _eerr_), *args);            \
-  __auto_type _s_ = _s0_;
-
-#define WITH(...) g_bind((__VA_ARGS__), _par_);
-
-#define DO_WITH(...) DO() WITH(__VA_ARGS__)
-
-#define SCAN(...) CAT(SCAN, VARIADIC_SIZE(__VA_ARGS__))(__VA_ARGS__)
-
-#define SCAN1(_p_)                                                       \
-  __auto_type TMPID = runParsec(_p_, _s_);                               \
-  _s_ = TMPID.result.state;                                              \
-  do {                                                                   \
-    if (!TMPID.result.success) {                                         \
-      Stream(CPARSEC_STREAM_TYPE) SS =                                   \
-          trait(Stream(CPARSEC_STREAM_TYPE));                            \
-      __auto_type _err_ =                                                \
-          (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cerr_ : _eerr_);      \
-      return fn_apply(_err_, TMPID.result.err, _s_);                     \
-    }                                                                    \
-  } while (0)
-
-#define SCAN2(_p_, _x_)                                                  \
-  SCAN1(_p_);                                                            \
-  __auto_type _x_ = TMPID.result.ok;
-
-#define FAIL(_msg_)                                                      \
-  do {                                                                   \
-    Stream(CPARSEC_STREAM_TYPE) SS = trait(Stream(CPARSEC_STREAM_TYPE)); \
-    __auto_type _err_ =                                                  \
-        (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cerr_ : _eerr_);        \
-    Hints(CPARSEC_STREAM_TYPE) empty_hints = {0};                        \
-    ParseError(CPARSEC_STREAM_TYPE) e =                                  \
-        trait(ParseError(CPARSEC_STREAM_TYPE))                           \
-            .unexpected_label(SS.offsetOf(_s_), _msg_, empty_hints);     \
-    return fn_apply(_err_, e, _s_);                                      \
-  } while (0)
-
-#define RETURN(_x_)                                                      \
-  do {                                                                   \
-    Stream(CPARSEC_STREAM_TYPE) SS = trait(Stream(CPARSEC_STREAM_TYPE)); \
-    __auto_type _ok_ =                                                   \
-        (SS.offsetOf(_s0_) < SS.offsetOf(_s_) ? _cok_ : _eok_);          \
-    Hints(CPARSEC_STREAM_TYPE) empty_hints = {0};                        \
-    return fn_apply(_ok_, _x_, _s_, empty_hints);                        \
-  } while (0)

--- a/test/testit/src/cparsec3/parsec/myparsec.c
+++ b/test/testit/src/cparsec3/parsec/myparsec.c
@@ -3,3 +3,12 @@
 /* generate parsec code if defined */
 #define CPARSEC_CONFIG_IMPLEMENT
 #include "myparsec.h"
+
+parsec(abc, String) {
+  DO() {
+    SCAN(char1('a'));
+    SCAN(char1('b'));
+    SCAN(char1('c'));
+    RETURN("abc");
+  }
+}

--- a/test/testit/src/cparsec3/parsec/myparsec.h
+++ b/test/testit/src/cparsec3/parsec/myparsec.h
@@ -9,3 +9,5 @@
 #include <cparsec3/easy_parsec/parser/failure.h>
 #include <cparsec3/easy_parsec/parser/repeat.h>
 #include <cparsec3/easy_parsec/parser/token.h>
+
+extern PARSER(String) abc(void);

--- a/test/testit/src/cparsec3/parsec/test_many.c
+++ b/test/testit/src/cparsec3/parsec/test_many.c
@@ -59,19 +59,6 @@ test("[parser] many(string1(\"\")), \"abc\" -> empty error") {
   c_assert(g_eq(r.state, "abc"));
 }
 
-fn(abcFn, UnParserArgs(S, String)) {
-  DO() {
-    SCAN(char1('a'));
-    SCAN(char1('b'));
-    SCAN(char1('c'));
-    RETURN("abc");
-  }
-}
-
-static Parsec(S, String) abc(void) {
-  return (Parsec(S, String)){abcFn()};
-}
-
 test("[parser] many(abc()), \"abc\" -> consumed ok") {
   ParseResult(S, Array(String)) r = runParser(many(abc()), "abc");
   c_assert(r.success);

--- a/test/testit/src/cparsec3/parsec/test_some.c
+++ b/test/testit/src/cparsec3/parsec/test_some.c
@@ -57,19 +57,6 @@ test("[parser] some(string1(\"\")), \"abc\" -> empty error") {
   c_assert(g_eq(r.state, "abc"));
 }
 
-fn(abcFn, UnParserArgs(S, String)) {
-  DO() {
-    SCAN(char1('a'));
-    SCAN(char1('b'));
-    SCAN(char1('c'));
-    RETURN("abc");
-  }
-}
-
-static Parsec(S, String) abc(void) {
-  return (Parsec(S, String)){abcFn()};
-}
-
 test("[parser] some(abc()), \"abc\" -> consumed ok") {
   ParseResult(S, Array(String)) r = runParser(some(abc()), "abc");
   c_assert(r.success);


### PR DESCRIPTION
- added `parsec(name, T..., R) {...}` macro
- added `PARSER(R)` macro, which is same as `Parsec(CPARSEC_STREAM_TYPE, R)`
- changed spec of `DO()` macro
- added `WITH(...)` macro
- `DO_WITH(...)` is now equivalent to `DO() WITH(...)`

~~~c
// PARSER(String) foo(int n, char c);
parsec(foo, int, char, String) {
  DO() WITH(n, c) {
    // ...
    String ret = ...;
    RETURN(ret);
  }
}
~~~
