### PR TITLE
fixed definition of `String` type ; `const char*` -> `char*`

### DIFF
--- a/docs/api-misc.org
+++ b/docs/api-misc.org
@@ -38,7 +38,7 @@ and *Generic Macros* in the library implementation.
      a 8-bit character
 
 - String          ::
-     a string. - type alias to ~const char*~ (i.e. *typedef*)
+     a string. - type alias to ~char*~ (i.e. *typedef*)
 
 - int             ::
      an integer.

--- a/include/cparsec3/base/common.h
+++ b/include/cparsec3/base/common.h
@@ -108,8 +108,7 @@
 
 C_API_BEGIN
 
-typedef const char* String;
-typedef int Int;
+typedef char* String;
 typedef intmax_t Offset;
 
 C_API_END


### PR DESCRIPTION
fixed definition of `String` type, and removed `Int` an unused type alias.