### PR TITLE
changed associativity of assignment and comparison operators.

### DIFF
--- a/example/pug-lang/README.org
+++ b/example/pug-lang/README.org
@@ -43,20 +43,20 @@ $ ./bin/pug -e '1 + 2;'
 | ~{...}~ | block           |
 
 ** Binary operators
-| Operator | Example        | Explanation                         |
-|----------+----------------+-------------------------------------|
-| ~=~      | ~var = expr~   | assignment                          |
-| ~==~     | ~expr == expr~ | equality comparison                 |
-| ~!=~     | ~expr != expr~ | nonequality comparison              |
-| ~<=~     | ~expr <= expr~ | less than or equal to comparison    |
-| ~<~      | ~expr < expr~  | less than comparison                |
-| ~>=~     | ~expr >= expr~ | greater than or equal to comparison |
-| ~>~      | ~expr > expr~  | greater than comparison             |
-| ~+~      | ~expr + expr~  | arithmetic addition                 |
-| ~-~      | ~expr - expr~  | arithmetic subtraction              |
-| ~*~      | ~expr * expr~  | arithmetic multiplication           |
-| ~/~      | ~expr / expr~  | arithmetic division                 |
-| ~%~      | ~expr % expr~  | arithmetic reminder                 |
+| Operator | Associativity    | Example        | Explanation                         |
+|----------+------------------+----------------+-------------------------------------|
+| ~=~      | non-associative  | ~var = expr~   | assignment                          |
+| ~==~     | non-associative  | ~expr == expr~ | equality comparison                 |
+| ~!=~     | non-associative  | ~expr != expr~ | nonequality comparison              |
+| ~<=~     | non-associative  | ~expr <= expr~ | less than or equal to comparison    |
+| ~<~      | non-associative  | ~expr < expr~  | less than comparison                |
+| ~>=~     | non-associative  | ~expr >= expr~ | greater than or equal to comparison |
+| ~>~      | non-associative  | ~expr > expr~  | greater than comparison             |
+| ~+~      | left-associative | ~expr + expr~  | arithmetic addition                 |
+| ~-~      | left-associative | ~expr - expr~  | arithmetic subtraction              |
+| ~*~      | left-associative | ~expr * expr~  | arithmetic multiplication           |
+| ~/~      | left-associative | ~expr / expr~  | arithmetic division                 |
+| ~%~      | left-associative | ~expr % expr~  | arithmetic reminder                 |
 
 ** Unary operators
 | Operator | Example  | Explanation            |

--- a/example/pug-lang/include/parser/expr.h
+++ b/example/pug-lang/include/parser/expr.h
@@ -59,7 +59,7 @@ parsec(assign, Expr) {
     if (m.none) {
       RETURN(lhs);
     }
-    SCAN(assign(), rhs);
+    SCAN(p, rhs);
     RETURN(E.assign(lhs, rhs));
   }
 }
@@ -71,14 +71,12 @@ parsec(equality, Expr) {
   PARSER(String) op = lexme(either(string1("=="), string1("!=")));
   DO() {
     SCAN(p, lhs);
-    for (;;) {
-      SCAN(optional(op), m);
-      if (m.none) {
-        break;
-      }
-      SCAN(p, rhs);
-      lhs = (g_eq("==", m.value) ? E.eq : E.neq)(lhs, rhs);
+    SCAN(optional(op), m);
+    if (m.none) {
+      RETURN(lhs);
     }
+    SCAN(p, rhs);
+    lhs = (g_eq("==", m.value) ? E.eq : E.neq)(lhs, rhs);
     RETURN(lhs);
   }
 }
@@ -91,16 +89,17 @@ parsec(ordered, Expr) {
   PARSER(char) op2 = char1('=');
   DO() {
     SCAN(p, lhs);
-    for (;;) {
-      SCAN(optional(op1), lg);
-      if (lg.none) {
-        break;
-      }
-      SCAN(optional(op2), e);
-      SCAN(space());
-      SCAN(p, rhs);
-      lhs = ((e.none) ? ((lg.value == '<') ? E.lt : E.gt)
-                      : ((lg.value == '<') ? E.le : E.ge))(lhs, rhs);
+    SCAN(optional(op1), lg);
+    if (lg.none) {
+      RETURN(lhs);
+    }
+    SCAN(optional(op2), e);
+    SCAN(space());
+    SCAN(p, rhs);
+    if (e.none) {
+      lhs = ((lg.value == '<') ? E.lt : E.gt)(lhs, rhs);
+    } else {
+      lhs = ((lg.value == '<') ? E.le : E.ge)(lhs, rhs);
     }
     RETURN(lhs);
   }

--- a/example/pug-lang/src/main.c
+++ b/example/pug-lang/src/main.c
@@ -204,15 +204,54 @@ void pug_self_test(void) {
   assert(pug_parseTest("1 > 10;"));  /* 0 */
   assert(pug_parseTest("1 >= 10;")); /* 0 */
 
-  assert(pug_parseTest("a;"));         /* 0 */
-  assert(pug_parseTest("a = b = 1;")); /* 1 */
+  /* assignment expression results the value assigned. */
+  assert(pug_parseTest("a = 100;")); /* 100 */
 
-  assert(pug_parseTest(";"));        /* () */
-  assert(!pug_parseTest("1"));       /* syntax error */
-  assert(pug_parseTest("1;"));       /* 1 */
+  /* evaluating a variable results its value. */
+  assert(pug_parseTest("a = 100; a;")); /* 100 */
+
+  /* evaluating an undefined variable results 0. */
+  assert(pug_parseTest("a;")); /* 0 */
+
+  /* arithmetic operators are left-associative. */
+  assert(pug_parseTest("100 + 2 + 3 == (100 + 2) + 3;"));
+  assert(pug_parseTest("100 - 2 - 3 == (100 - 2) - 3;"));
+  assert(pug_parseTest("100 * 2 * 3 == (100 * 2) * 3;"));
+  assert(pug_parseTest("100 / 2 / 5 == (100 / 2) / 5;"));
+
+  /* comparison operators are non-associative */
+  assert(!pug_parseTest("1 == 2 == 0;")); /* syntax error */
+  assert(!pug_parseTest("1 != 2 == 1;")); /* syntax error */
+  assert(!pug_parseTest("2 != 2 == 0;")); /* syntax error */
+  assert(!pug_parseTest("2 == 2 == 1;")); /* syntax error */
+  assert(!pug_parseTest("1 <= 2 <= 3;")); /* syntax error */
+  assert(!pug_parseTest("1 <= 2 < 3;"));  /* syntax error */
+  assert(!pug_parseTest("1 < 2 <= 3;"));  /* syntax error */
+  assert(!pug_parseTest("1 < 2 < 3;"));   /* syntax error */
+  assert(!pug_parseTest("3 >= 2 >= 1;")); /* syntax error */
+  assert(!pug_parseTest("3 >= 2 > 1;"));  /* syntax error */
+  assert(!pug_parseTest("3 > 2 >= 1;"));  /* syntax error */
+  assert(!pug_parseTest("3 > 2 > 1;"));   /* syntax error */
+
+  /* assignment operators are non-associative. */
+  assert(!pug_parseTest("a = b = 1;")); /* syntax error */
+
+  /* empty statement results `()`. */
+  assert(pug_parseTest(";")); /* () */
+
+  /* a statement must be block or ends with ';' */
+  assert(!pug_parseTest("1"));   /* syntax error */
+  assert(pug_parseTest("1;"));   /* 1 */
+  assert(pug_parseTest("{1;}")); /* 1 */
+
+  /* empty block is not permitted. */
+  assert(!pug_parseTest("{}")); /* syntax error */
+  assert(pug_parseTest("{;}")); /* () */
+
+  /* a list of statements are evaluated in order, and results the last
+   * value. */
   assert(pug_parseTest("1;2;"));     /* 2 */
   assert(pug_parseTest("1;2;3;"));   /* 3 */
-  assert(pug_parseTest("{1;}"));     /* 1 */
   assert(pug_parseTest("{1;2;}"));   /* 2 */
   assert(pug_parseTest("{1;2;3;}")); /* 3 */
   assert(pug_parseTest("{1;};"));    /* () */


### PR DESCRIPTION
Now assignment and comparison operators are non-associative.
i.e. `expr < expr < expr` is not permitted, for example.
