### PR TITLE
refactored `expr()` and fixed `stmt_list()`.

### DIFF
--- a/example/pug-lang/README.org
+++ b/example/pug-lang/README.org
@@ -26,9 +26,17 @@ $ ./bin/pug --help
 
 * Example
 #+begin_src shell
-$ ./bin/pug -e '1 + 2;'
-> 1 + 2;
->> (Add (Num 1) (Num 2))
+$ ./bin/pug -e '1 + 2'
+> 1 + 2
+>> (Add 1 2)
+3
+
+#+end_src
+
+#+begin_src shell
+$ ./bin/pug -e 'let x = 1; let y = 2; x + y'
+> let x = 1; let y = 2; x + y
+>> (Seq (Let (Var x) 1) (Seq (Let (Var y) 2) (Add (Var x) (Var y))))
 3
 
 #+end_src
@@ -36,12 +44,12 @@ $ ./bin/pug -e '1 + 2;'
 * Pug programming language
 
 ** Statements
-| Example           | Explanation         |
-|-------------------+---------------------|
-| ~let var = expr;~ | variable definition |
-| ~expr;~           | statement           |
-| ~;~               | empty statement     |
-| ~{...}~           | block               |
+| Example                               | Explanation         |
+|---------------------------------------+---------------------|
+| ~let var = expr~                      | variable definition |
+| ~expr~                                | expression          |
+| ~{...; ...; ...}~, ~{...; ...; ...;}~ | block               |
+| ~...; ...; ...~, ~...; ...; ...;~     | list of statements  |
 
 ** Binary operators
 | Operator | Associativity    | Example        | Explanation                         |
@@ -60,11 +68,11 @@ $ ./bin/pug -e '1 + 2;'
 | ~%~      | left-associative | ~expr % expr~  | arithmetic reminder                 |
 
 ** Unary operators
-| Operator | Example  | Explanation            |
-|----------+----------+------------------------|
-| ~+~      | ~+ expr~ | (equivalent to ~expr~) |
-| ~-~      | ~- expr~ | arithmetic negation    |
-| ~!~      | ~! expr~ | not                    |
+| Operator | Example  | Explanation                      |
+|----------+----------+----------------------------------|
+| ~+~      | ~+ expr~ | (equivalent to ~expr~)           |
+| ~-~      | ~- expr~ | arithmetic negation              |
+| ~!~      | ~! expr~ | logical not / bitwise complement |
 
 ** Parenthesis
 | Example  | Explanation              |

--- a/example/pug-lang/include/parser/expr.h
+++ b/example/pug-lang/include/parser/expr.h
@@ -201,7 +201,7 @@ parsec(addsub, Expr) {
 // PARSER(Expr) muldiv(void);
 parsec(muldiv, Expr) {
   ExprT E = trait(Expr);
-  PARSER(Expr) p = unary();
+  PARSER(Expr) p = expr8();
   PARSER(char) op = lexme(choice(char1('*'), char1('/'), char1('%')));
   DO() {
     SCAN(p, lhs);

--- a/example/pug-lang/include/parser/expr.h
+++ b/example/pug-lang/include/parser/expr.h
@@ -10,35 +10,63 @@
 
 C_API_BEGIN
 
-// expr     = assign
-// assign   = equality {"=" equality}
-// equality = ordered {("==" | "!=") ordered}
-// ordered  = addsub {("<=" | "<" | ">" | ">=") addsub}
-// addsub   = muldiv {("+" | "-") muldiv}
-// muldiv   = unary {("*" | "/") unary}
-// unary    = [("+" | "-" | "!")] primary
-// primary  = ctor | paren | number | variable
-// ctor     = "()" | "true" | "false"
-// paren    = (" expr ")"
-// variable = identifier
+// expr   = assign
+// assign = expr0 {"=" expr0}
+// expr0  = expr1
+// expr1  = expr2
+// expr2  = expr3 {"||" expr3}
+// expr3  = expr4 {"&&" expr4}
+// expr4  = expr5 [("==" | "!=" | "<=" | "<" | ">" | ">=") expr5]
+// expr5  = expr6
+// expr6  = expr7 {("+" | "-") expr7}
+// expr7  = expr8 {("*" | "/") expr8}
+// expr8  = expr9
+// expr9  = expr10
+// expr10 = unary
+// unary  = [("+" | "-" | "!")] fexpr
+// fexpr  = [fexpr] aexpr
+// aexpr  = qvar
+//        | ctor
+//        | literal
+//        | paren
 //
+// qvar    = variable
+// ctor    = "()" | "true" | "false"
+// literal = number
+// paren   = (" expr ")"
+//
+// variable    = identifier
 // identifier  = identStart{identLetter}
 // identStart  = "_" | letter
 // identLetter = "_" | alphaNum
 
 PARSER(Expr) expr(void);
 PARSER(Expr) assign(void);
-PARSER(Expr) equality(void);
-PARSER(Expr) ordered(void);
-PARSER(Expr) addsub(void);
-PARSER(Expr) muldiv(void);
+
+PARSER(Expr) expr0(void);
+PARSER(Expr) expr1(void);
+PARSER(Expr) expr2(void);
+PARSER(Expr) expr3(void);
+PARSER(Expr) expr4(void);
+PARSER(Expr) expr5(void);
+PARSER(Expr) expr6(void);
+PARSER(Expr) expr7(void);
+PARSER(Expr) expr8(void);
+PARSER(Expr) expr9(void);
+PARSER(Expr) expr10(void);
+
+PARSER(Expr) comparison(void); /* 4 */
+PARSER(Expr) addsub(void);     /* 6 */
+PARSER(Expr) muldiv(void);     /* 7 */
 PARSER(Expr) unary(void);
-PARSER(Expr) primary(void);
-PARSER(Expr) ctor(String symbol, Expr e);
+PARSER(Expr) fexpr(void); /* funcion application */
+PARSER(Expr) aexpr(void);
+PARSER(Expr) qvar(void); /* qualified variable */
+PARSER(Expr) ctor(void); /* data constructor */
+PARSER(Expr) literal(void);
 PARSER(Expr) paren(void);
 
 PARSER(Expr) variable(void);
-
 PARSER(String) identifier(void);
 PARSER(char) identStart(void);
 PARSER(char) identLetter(void);
@@ -71,7 +99,7 @@ PARSER(Expr) expr(void) {
 // PARSER(Expr) assign(void);
 parsec(assign, Expr) {
   ExprT E = trait(Expr);
-  PARSER(Expr) p = equality();
+  PARSER(Expr) p = expr0();
   PARSER(char) op = lexme(char1('='));
   DO() {
     SCAN(p, lhs);
@@ -87,11 +115,49 @@ parsec(assign, Expr) {
   }
 }
 
-// PARSER(Expr) equality(void);
-parsec(equality, Expr) {
+PARSER(Expr) expr0(void) {
+  return expr1();
+}
+PARSER(Expr) expr1(void) {
+  return expr2();
+}
+PARSER(Expr) expr2(void) {
+  return expr3();
+}
+PARSER(Expr) expr3(void) {
+  return expr4();
+}
+PARSER(Expr) expr4(void) {
+  return comparison();
+}
+PARSER(Expr) expr5(void) {
+  return expr6();
+}
+PARSER(Expr) expr6(void) {
+  return addsub();
+}
+PARSER(Expr) expr7(void) {
+  return muldiv();
+}
+PARSER(Expr) expr8(void) {
+  return expr9();
+}
+PARSER(Expr) expr9(void) {
+  return expr10();
+}
+PARSER(Expr) expr10(void) {
+  return unary();
+}
+
+// PARSER(Expr) comparison(void);
+parsec(comparison, Expr) {
   ExprT E = trait(Expr);
-  PARSER(Expr) p = ordered();
-  PARSER(String) op = lexme(either(string1("=="), string1("!=")));
+  PARSER(Expr) p = expr5();
+  PARSER(String)
+  op = lexme(choice(string1("=="), string1("!="), /* eq, neq */
+                    string1("<="), string1(">="), /* le, ge */
+                    string1("<"), string1(">"))   /* lt, gt */
+  );
   DO() {
     SCAN(p, lhs);
     SCAN(optional(op), m);
@@ -99,39 +165,24 @@ parsec(equality, Expr) {
       RETURN(lhs);
     }
     SCAN(p, rhs);
-    lhs = (g_eq("==", m.value) ? E.eq : E.neq)(lhs, rhs);
-    RETURN(lhs);
-  }
-}
-
-// PARSER(Expr) ordered(void);
-parsec(ordered, Expr) {
-  ExprT E = trait(Expr);
-  PARSER(Expr) p = addsub();
-  PARSER(char) op1 = either(char1('<'), char1('>'));
-  PARSER(char) op2 = char1('=');
-  DO() {
-    SCAN(p, lhs);
-    SCAN(optional(op1), lg);
-    if (lg.none) {
-      RETURN(lhs);
+    if (g_eq("==", m.value)) {
+      RETURN(E.eq(lhs, rhs));
     }
-    SCAN(optional(op2), e);
-    SCAN(space());
-    SCAN(p, rhs);
-    if (e.none) {
-      lhs = ((lg.value == '<') ? E.lt : E.gt)(lhs, rhs);
+    if (g_eq("!=", m.value)) {
+      RETURN(E.neq(lhs, rhs));
+    }
+    if (!m.value[1]) {
+      RETURN(((m.value[0] == '<') ? E.lt : E.gt)(lhs, rhs));
     } else {
-      lhs = ((lg.value == '<') ? E.le : E.ge)(lhs, rhs);
+      RETURN(((m.value[0] == '<') ? E.le : E.ge)(lhs, rhs));
     }
-    RETURN(lhs);
   }
 }
 
 // PARSER(Expr) addsub(void);
 parsec(addsub, Expr) {
   ExprT E = trait(Expr);
-  PARSER(Expr) p = muldiv();
+  PARSER(Expr) p = expr7();
   PARSER(char) op = lexme(either(char1('+'), char1('-')));
   DO() {
     SCAN(p, lhs);
@@ -182,7 +233,7 @@ parsec(muldiv, Expr) {
 // PARSER(Expr) unary(void);
 parsec(unary, Expr) {
   ExprT E = trait(Expr);
-  PARSER(Expr) p = primary();
+  PARSER(Expr) p = fexpr();
   PARSER(char) op = lexme(choice(char1('+'), char1('-'), char1('!')));
   DO() {
     SCAN(optional(op), m);
@@ -204,26 +255,41 @@ parsec(unary, Expr) {
   }
 }
 
-// PARSER(Expr) primary(void);
-parsec(primary, Expr) {
-  ExprT E = trait(Expr);
+PARSER(Expr) fexpr(void) {
+  return aexpr();
+}
+
+// PARSER(Expr) aexpr(void);
+parsec(aexpr, Expr) {
   DO() {
-    SCAN(choice(ctor("()", E.unit()),            /* () */
-                ctor("true", E.boolean(true)),   /* true */
-                ctor("false", E.boolean(false)), /* false */
-                paren(), number(), variable()),
-         x);
+    SCAN(choice(qvar(), ctor(), literal(), paren()), x);
     SCAN(space());
     RETURN(x);
   }
 }
 
-// PARSER(Expr) ctor(String symbol, Expr e);
-parsec(ctor, String, Expr, Expr) {
+PARSER(Expr) qvar(void) {
+  return variable();
+}
+
+// PARSER(Expr) ctor0(String symbol, Expr e);
+parsec(ctor0, String, Expr, Expr) {
   DO() WITH(s, e) {
     SCAN(keyword(s));
     RETURN(e);
   }
+}
+
+PARSER(Expr) ctor(void) {
+  ExprT E = trait(Expr);
+  return choice(ctor0("()", E.unit()),           /* () */
+                ctor0("true", E.boolean(true)),  /* true */
+                ctor0("false", E.boolean(false)) /* false */
+  );
+}
+
+PARSER(Expr) literal(void) {
+  return number();
 }
 
 // PARSER(Expr) paren(void);

--- a/example/pug-lang/include/parser/optional.h
+++ b/example/pug-lang/include/parser/optional.h
@@ -6,13 +6,15 @@
 C_API_BEGIN
 
 #define GENERIC_OPTIONAL(T) FUNC_NAME(optional, T)
-#define optional(p) GENERIC(p, PARSER, GENERIC_OPTIONAL, char, String)(p)
+#define optional(p)                                                      \
+  GENERIC(p, PARSER, GENERIC_OPTIONAL, char, String, Expr)(p)
 
 #define decl_optional(T)                                                 \
   PARSER(Maybe(T)) FUNC_NAME(optional, T)(PARSER(T) p)
 
 decl_optional(char);
 decl_optional(String);
+decl_optional(Expr);
 
 // -----------------------------------------------------------------------
 #if defined(CPARSEC_CONFIG_IMPLEMENT)
@@ -33,6 +35,7 @@ decl_optional(String);
 
 impl_optional(char);
 impl_optional(String);
+impl_optional(Expr);
 
 #endif
 

--- a/example/pug-lang/include/parser/stmt.h
+++ b/example/pug-lang/include/parser/stmt.h
@@ -8,23 +8,17 @@
 C_API_BEGIN
 
 // program    = stmt-list eof
-// stmt-list  = stmt {stmt}
-// stmt       = let | stmt1
-// stmt1      = block | empty_stmt | expr_stmt
-// let        = "let" variable "=" equality
+// stmt-list  = stmt {";" [stmt]}
+// stmt       = let | block | expr
+// let        = "let" variable "=" expr0 ";"
 // block      = "{" stmt-list "}"
-// empty_stmt = ";"
-// expr_stmt  = expr ";"
 
 PARSER(Expr) program(void);
 
 PARSER(Expr) stmt_list(void);
 PARSER(Expr) stmt(void);
-PARSER(Expr) stmt1(void);
 PARSER(Expr) let(void);
 PARSER(Expr) block(void);
-PARSER(Expr) empty_stmt(void);
-PARSER(Expr) expr_stmt(void);
 
 // -----------------------------------------------------------------------
 #if defined(CPARSEC_CONFIG_IMPLEMENT)
@@ -41,48 +35,35 @@ parsec(program, Expr) {
 // PARSER(Expr) stmt_list(void);
 parsec(stmt_list, Expr) {
   ExprT E = trait(Expr);
-  ArrayT(Expr) A = trait(Array(Expr));
+  PARSER(char) semi = lexme(char1(';'));
   DO() {
-    SCAN(some(stmt()), a);
-    Expr* p = A.end(a) - 1;
-    Expr q = *p;
-    while (p != A.begin(a)) {
-      q = E.seq(*--p, q);
+    SCAN(stmt(), lhs);
+    SCAN(optional(semi), m);
+    if (m.none) {
+      RETURN(lhs);
     }
-    RETURN(q);
+    SCAN(optional(stmt_list()), rhs);
+    if (rhs.none) {
+      RETURN(lhs);
+    }
+    RETURN(E.seq(lhs, rhs.value));
   }
 }
 
 PARSER(Expr) stmt(void) {
-  return choice(let(), stmt1());
-}
-
-PARSER(Expr) stmt1(void) {
-  return choice(block(), empty_stmt(), expr_stmt());
+  return choice(let(), block(), expr());
 }
 
 // PARSER(Expr) let(void);
 parsec(let, Expr) {
   ExprT E = trait(Expr);
   PARSER(char) op = lexme(char1('='));
-  PARSER(char) semi = lexme(char1(';'));
   DO() {
     SCAN(lexme(keyword("let")));
     SCAN(variable(), lhs);
     SCAN(op);
-    SCAN(equality(), rhs);
-    SCAN(semi);
+    SCAN(expr0(), rhs);
     RETURN(E.let(lhs, rhs));
-  }
-}
-
-// PARSER(Expr) empty_stmt(void);
-parsec(empty_stmt, Expr) {
-  ExprT E = trait(Expr);
-  PARSER(char) semi = lexme(char1(';'));
-  DO() {
-    SCAN(semi);
-    RETURN(E.unit());
   }
 }
 
@@ -94,16 +75,6 @@ parsec(block, Expr) {
     SCAN(open_brace);
     SCAN(stmt_list(), x);
     SCAN(close_brace);
-    RETURN(x);
-  }
-}
-
-// PARSER(Expr) expr_stmt(void);
-parsec(expr_stmt, Expr) {
-  PARSER(char) semi = lexme(char1(';'));
-  DO() {
-    SCAN(expr(), x);
-    SCAN(semi);
     RETURN(x);
   }
 }

--- a/example/pug-lang/src/main.c
+++ b/example/pug-lang/src/main.c
@@ -173,124 +173,132 @@ bool pug_parseTest(String input) {
 
 // -----------------------------------------------------------------------
 void pug_self_test(void) {
-  assert(pug_parseTest("123;"));
-  assert(pug_parseTest("12*3;"));
-  assert(pug_parseTest("12/3;"));
-  assert(pug_parseTest("(12*3)/4;"));
-  assert(pug_parseTest("(12/3)*4;"));
-  assert(pug_parseTest("12*(3/4);"));
-  assert(pug_parseTest("12/(3*4);"));
-  assert(pug_parseTest("(12*3)/(3*4);"));
-  assert(pug_parseTest("(12*3)/(34);"));
-  assert(!pug_parseTest("(12*3)(3*4);")); /* syntax error */
-  assert(!pug_parseTest("(12*3a);"));     /* syntax error */
-  assert(pug_parseTest("5+4*3-2/1;"));
-  assert(pug_parseTest("( 5 + 4 ) * 3 - 2 / 1 ;  "));
-  assert(pug_parseTest("-1;"));
-  assert(pug_parseTest("+1;"));
-  assert(pug_parseTest("- 1;"));
-  assert(pug_parseTest("+ 1;"));
-  assert(pug_parseTest("1 - -1;"));
-  assert(!pug_parseTest("9999999999999999999;")); /* syntax error */
-  assert(!pug_parseTest("1 / 0;"));               /* division by zero */
-  assert(!pug_parseTest("1 % 0;"));               /* division by zero */
-  assert(pug_parseTest("10 % 3;"));
-  assert(pug_parseTest("10 == 3;"));
-  assert(pug_parseTest("10 == 10;"));
-  assert(pug_parseTest("10 != 3;"));
-  assert(pug_parseTest("10 != 10;"));
-  assert(pug_parseTest("1 <= 10;")); /* 1 */
-  assert(pug_parseTest("1 < 10;"));  /* 1 */
-  assert(pug_parseTest("1 > 10;"));  /* 0 */
-  assert(pug_parseTest("1 >= 10;")); /* 0 */
+  assert(pug_parseTest("123"));
+  assert(pug_parseTest("12*3"));
+  assert(pug_parseTest("12/3"));
+  assert(pug_parseTest("(12*3)/4"));
+  assert(pug_parseTest("(12/3)*4"));
+  assert(pug_parseTest("12*(3/4)"));
+  assert(pug_parseTest("12/(3*4)"));
+  assert(pug_parseTest("(12*3)/(3*4)"));
+  assert(pug_parseTest("(12*3)/(34)"));
+  assert(!pug_parseTest("(12*3)(3*4)")); /* syntax error */
+  assert(!pug_parseTest("(12*3a)"));     /* syntax error */
+  assert(pug_parseTest("5+4*3-2/1"));
+  assert(pug_parseTest("( 5 + 4 ) * 3 - 2 / 1   "));
+  assert(pug_parseTest("-1"));
+  assert(pug_parseTest("+1"));
+  assert(pug_parseTest("- 1"));
+  assert(pug_parseTest("+ 1"));
+  assert(pug_parseTest("1 - -1"));
+  assert(!pug_parseTest("9999999999999999999")); /* syntax error */
+  assert(!pug_parseTest("1 / 0"));               /* division by zero */
+  assert(!pug_parseTest("1 % 0"));               /* division by zero */
+  assert(pug_parseTest("10 % 3"));
+  assert(pug_parseTest("10 == 3"));
+  assert(pug_parseTest("10 == 10"));
+  assert(pug_parseTest("10 != 3"));
+  assert(pug_parseTest("10 != 10"));
+  assert(pug_parseTest("1 <= 10")); /* 1 */
+  assert(pug_parseTest("1 < 10"));  /* 1 */
+  assert(pug_parseTest("1 > 10"));  /* 0 */
+  assert(pug_parseTest("1 >= 10")); /* 0 */
 
   /* a variable must be initialized when defining it. */
-  assert(pug_parseTest("let a = 100;")); /* 100 */
+  assert(pug_parseTest("let a = 100")); /* 100 */
 
   /* defining the same variable, the previous one will be shadowed. */
-  assert(pug_parseTest("let a = 100; let a = 2;")); /* 2 */
+  assert(pug_parseTest("let a = 100; let a = 2")); /* 2 */
 
   /* defining the same variable of different type is permitted. the
    * previous one will be shadowed. */
-  assert(pug_parseTest("let a = 100; let a = true;")); /* true */
+  assert(pug_parseTest("let a = 100; let a = true")); /* true */
 
   /* evaluating a variable results its value. */
-  assert(pug_parseTest("let a = 100; a;")); /* 100 */
+  assert(pug_parseTest("let a = 100; a")); /* 100 */
 
   /* evaluating an undefined variable is not permitted. */
-  assert(!pug_parseTest("a;"));         /* Undefined variable */
-  assert(!pug_parseTest("let a = a;")); /* Undefined variable */
+  assert(!pug_parseTest("a"));         /* Undefined variable */
+  assert(!pug_parseTest("let a = a")); /* Undefined variable */
 
   /* assignment expression results the value assigned. */
-  assert(pug_parseTest("let a = 1; a = 100;")); /* 100 */
+  assert(pug_parseTest("let a = 1; a = 100")); /* 100 */
 
   /* assignment of different type is not permitted. */
-  assert(!pug_parseTest("let a = 1; a = ();")); /* Type mismatch */
+  assert(!pug_parseTest("let a = 1; a = ()")); /* Type mismatch */
 
   /* comparison operators results `true` or `false` */
-  assert(pug_parseTest("1 == 1;"));                     /* true */
-  assert(pug_parseTest("0 == 1;"));                     /* false */
-  assert(pug_parseTest("let a = 0 < 1; a == true ;"));  /* true */
-  assert(pug_parseTest("let a = 1 < 1; a == false ;")); /* true */
+  assert(pug_parseTest("1 == 1"));                     /* true */
+  assert(pug_parseTest("0 == 1"));                     /* false */
+  assert(pug_parseTest("let a = 0 < 1; a == true "));  /* true */
+  assert(pug_parseTest("let a = 1 < 1; a == false ")); /* true */
 
   /* `!expr` results the complement of `expr` if `expr` was integer. */
-  assert(pug_parseTest("!0 ;")); /* -1 */
-  assert(pug_parseTest("!1 ;")); /* -2 */
+  assert(pug_parseTest("!0 ")); /* -1 */
+  assert(pug_parseTest("!1 ")); /* -2 */
 
   /* `!expr` results the logical `not` of `expr` if `expr` was bool. */
-  assert(pug_parseTest("!true ;"));  /* false */
-  assert(pug_parseTest("!false ;")); /* true */
+  assert(pug_parseTest("!true "));  /* false */
+  assert(pug_parseTest("!false ")); /* true */
 
   /* arithmetic operators are left-associative. */
-  assert(pug_parseTest("100 + 2 + 3 == (100 + 2) + 3;"));
-  assert(pug_parseTest("100 - 2 - 3 == (100 - 2) - 3;"));
-  assert(pug_parseTest("100 * 2 * 3 == (100 * 2) * 3;"));
-  assert(pug_parseTest("100 / 2 / 5 == (100 / 2) / 5;"));
+  assert(pug_parseTest("100 + 2 + 3 == (100 + 2) + 3"));
+  assert(pug_parseTest("100 - 2 - 3 == (100 - 2) - 3"));
+  assert(pug_parseTest("100 * 2 * 3 == (100 * 2) * 3"));
+  assert(pug_parseTest("100 / 2 / 5 == (100 / 2) / 5"));
 
   /* comparison operators are non-associative */
-  assert(!pug_parseTest("1 == 2 == 0;")); /* syntax error */
-  assert(!pug_parseTest("1 != 2 == 1;")); /* syntax error */
-  assert(!pug_parseTest("2 != 2 == 0;")); /* syntax error */
-  assert(!pug_parseTest("2 == 2 == 1;")); /* syntax error */
-  assert(!pug_parseTest("1 <= 2 <= 3;")); /* syntax error */
-  assert(!pug_parseTest("1 <= 2 < 3;"));  /* syntax error */
-  assert(!pug_parseTest("1 < 2 <= 3;"));  /* syntax error */
-  assert(!pug_parseTest("1 < 2 < 3;"));   /* syntax error */
-  assert(!pug_parseTest("3 >= 2 >= 1;")); /* syntax error */
-  assert(!pug_parseTest("3 >= 2 > 1;"));  /* syntax error */
-  assert(!pug_parseTest("3 > 2 >= 1;"));  /* syntax error */
-  assert(!pug_parseTest("3 > 2 > 1;"));   /* syntax error */
+  assert(!pug_parseTest("1 == 2 == 0")); /* syntax error */
+  assert(!pug_parseTest("1 != 2 == 1")); /* syntax error */
+  assert(!pug_parseTest("2 != 2 == 0")); /* syntax error */
+  assert(!pug_parseTest("2 == 2 == 1")); /* syntax error */
+  assert(!pug_parseTest("1 <= 2 <= 3")); /* syntax error */
+  assert(!pug_parseTest("1 <= 2 < 3"));  /* syntax error */
+  assert(!pug_parseTest("1 < 2 <= 3"));  /* syntax error */
+  assert(!pug_parseTest("1 < 2 < 3"));   /* syntax error */
+  assert(!pug_parseTest("3 >= 2 >= 1")); /* syntax error */
+  assert(!pug_parseTest("3 >= 2 > 1"));  /* syntax error */
+  assert(!pug_parseTest("3 > 2 >= 1"));  /* syntax error */
+  assert(!pug_parseTest("3 > 2 > 1"));   /* syntax error */
 
   /* assignment operators are non-associative. */
-  assert(!pug_parseTest("let a = 0; let b = 0; a = b = 1;"));
+  assert(!pug_parseTest("let a = 0; let b = 0; a = b = 1"));
   /* -> syntax error */
 
-  /* empty statement results `()`. */
-  assert(pug_parseTest(";")); /* () */
-
-  /* a statement must be block or ends with ';' */
-  assert(!pug_parseTest("1"));   /* syntax error */
-  assert(pug_parseTest("1;"));   /* 1 */
-  assert(pug_parseTest("{1;}")); /* 1 */
+  /* a statement must be declaration, block, or expression. */
+  assert(pug_parseTest("let a = 1")); /* 1 */
+  assert(pug_parseTest("{1}"));       /* 1 */
+  assert(pug_parseTest("1"));         /* 1 */
 
   /* empty block is not permitted. */
   assert(!pug_parseTest("{}")); /* syntax error */
-  assert(pug_parseTest("{;}")); /* () */
+
+  /* empty statement is not permitted. */
+  assert(!pug_parseTest(";")); /* syntax error */
+
+  /* each statement in a list of statements must be separated by ";". */
+  assert(!pug_parseTest("1 2"));   /* syntax error */
+  assert(!pug_parseTest("1 {2}")); /* syntax error */
+  assert(!pug_parseTest("{1} 2")); /* syntax error */
+
+  /* a list of statements may ends with an optional ";". */
+  assert(pug_parseTest("1;"));    /* 1 */
+  assert(pug_parseTest("{1;}"));  /* 1 */
+  assert(pug_parseTest("{1};"));  /* 1 */
+  assert(pug_parseTest("{1;};")); /* 1 */
 
   /* a list of statements are evaluated in order, and results the last
    * value. */
-  assert(pug_parseTest("1;2;"));     /* 2 */
-  assert(pug_parseTest("1;2;3;"));   /* 3 */
-  assert(pug_parseTest("{1;2;}"));   /* 2 */
-  assert(pug_parseTest("{1;2;3;}")); /* 3 */
-  assert(pug_parseTest("{1;};"));    /* () */
-  assert(pug_parseTest("{1;} 2;"));  /* 2 */
-  assert(pug_parseTest("{1;}; 2;")); /* 2 */
-  assert(pug_parseTest("; {2;}"));   /* 2 */
-  assert(!pug_parseTest("1 {2;}"));  /* syntax error */
-  assert(pug_parseTest("1; {2;}"));  /* 2 */
+  assert(pug_parseTest("1;2"));      /* 2 */
+  assert(pug_parseTest("1;2;3"));    /* 3 */
+  assert(pug_parseTest("{1;2}"));    /* 2 */
+  assert(pug_parseTest("{1;2;3}"));  /* 3 */
+  assert(pug_parseTest("{1}"));      /* 1 */
+  assert(pug_parseTest("{1}; 2"));   /* 2 */
+  assert(pug_parseTest("1; {2}"));   /* 2 */
+  assert(pug_parseTest("{1}; {2}")); /* 2 */
 
-  assert(pug_parseTest("let a = 1; let b = 2; a + b;")); /* 3 */
-  assert(pug_parseTest("let a = 1; let b = 2; a;"));     /* 1 */
-  assert(pug_parseTest("let a = 1; let b = 2; b;"));     /* 2 */
+  assert(pug_parseTest("let a = 1; let b = 2; a + b")); /* 3 */
+  assert(pug_parseTest("let a = 1; let b = 2; a"));     /* 1 */
+  assert(pug_parseTest("let a = 1; let b = 2; b"));     /* 2 */
 }

--- a/example/pug-lang/src/main.c
+++ b/example/pug-lang/src/main.c
@@ -195,14 +195,18 @@ void pug_self_test(void) {
   assert(!pug_parseTest("1 / 0"));               /* division by zero */
   assert(!pug_parseTest("1 % 0"));               /* division by zero */
   assert(pug_parseTest("10 % 3"));
-  assert(pug_parseTest("10 == 3"));
-  assert(pug_parseTest("10 == 10"));
-  assert(pug_parseTest("10 != 3"));
-  assert(pug_parseTest("10 != 10"));
-  assert(pug_parseTest("1 <= 10")); /* 1 */
-  assert(pug_parseTest("1 < 10"));  /* 1 */
-  assert(pug_parseTest("1 > 10"));  /* 0 */
-  assert(pug_parseTest("1 >= 10")); /* 0 */
+  assert(pug_parseTest("10 == 3"));  /* false */
+  assert(pug_parseTest("10 == 10")); /* true */
+  assert(pug_parseTest("10 != 3"));  /* true */
+  assert(pug_parseTest("10 != 10")); /* false */
+  assert(pug_parseTest("1 <= 10"));  /* true */
+  assert(pug_parseTest("1 < 10"));   /* true */
+  assert(pug_parseTest("1 > 10"));   /* false */
+  assert(pug_parseTest("1 >= 10"));  /* false */
+  assert(pug_parseTest("!0 == -1"));
+  assert(pug_parseTest("!1 == -2"));
+  assert(pug_parseTest("!true == false"));
+  assert(pug_parseTest("!false == true"));
 
   /* a variable must be initialized when defining it. */
   assert(pug_parseTest("let a = 100")); /* 100 */


### PR DESCRIPTION
- Each statement must be separated by ";".
- A list of statements may ends with an optional ";".
- An empty statement is not permitted.