### PR TITLE
fixed #131 : `Parsec(S, Maybe(None))` shall be supported in default.

### DIFF
--- a/include/cparsec3/easy_parsec/config.h
+++ b/include/cparsec3/easy_parsec/config.h
@@ -10,11 +10,11 @@
 #define CPARSEC_USER_TYPES() CPARSEC_CONFIG_USER_TYPES
 #endif
 
-#define PARSER_RETURN_TYPES(S)                                          \
-  None, PARSER_RETURN_TYPES_0(S), APPLY(Array, PARSER_RETURN_TYPES_0(S))
+#define PARSER_RETURN_TYPES(S)                                           \
+  PARSER_RETURN_TYPES_0(S), APPLY(Array, PARSER_RETURN_TYPES_0(S))
 
-#define PARSER_RETURN_TYPES_0(S)                    \
-  SQUASH(Token(S), Tokens(S), CPARSEC_USER_TYPES())
+#define PARSER_RETURN_TYPES_0(S)                                         \
+  SQUASH(None, Token(S), Tokens(S), CPARSEC_USER_TYPES())
 
 // -----------------------------------------------------------------------
 #if !defined(CPARSEC_CONFIG_DATA_SOURCE)


### PR DESCRIPTION
fixed #131 