### PR TITLE
refactored and reduced memory allocation for lazy evaluation.

### DIFF
--- a/example/pug-lang/include/interpreter/interpreter.h
+++ b/example/pug-lang/include/interpreter/interpreter.h
@@ -6,6 +6,24 @@
 
 #define Interpreter(...) TYPE_NAME(Interpreter, __VA_ARGS__)
 
+#define EVAL_RESULT_OK(_x_)                                              \
+  ((EvalResult){                                                         \
+      .success = true,                                                   \
+      .ok = _x_,                                                         \
+  })
+
+#define EVAL_RESULT_ERR(_msg_)                                           \
+  ((EvalResult){                                                         \
+      .err.msg = _msg_,                                                  \
+  })
+
+#define EVAL_RESULT_DEFERED(_ctx_, _x_)                                  \
+  ((EvalResult){                                                         \
+      .success = true,                                                   \
+      .ok = _x_,                                                         \
+      .ctx = _ctx_,                                                      \
+  })
+
 typedef struct RuntimeError {
   String msg;
 } RuntimeError;
@@ -13,7 +31,11 @@ typedef struct RuntimeError {
 typedef struct EvalResult {
   bool success;
   union {
-    Expr ok;
+    struct {
+      Expr ok;
+      /** non-null if this was a 'thunk' (i.e. evaluation was defered) */
+      Context ctx;
+    };
     RuntimeError err;
   };
 } EvalResult;


### PR DESCRIPTION
In the past, when a `thunk` object was created it was destructed soon.
It means that a memory allocated for a `thunk` will be a garbage soon
at the next evaluation step.

At this commit, we done the following:
- Removed `thunk` object.
- Instead, `EvalResult` struct can represents a defered expression.

i.e. memory allocation for `thunk` is no longer needed.