### PR TITLE
a parenthesized operator symbol may be used as a variable.

### DIFF
--- a/example/pug-lang/src/test.c
+++ b/example/pug-lang/src/test.c
@@ -296,4 +296,7 @@ void pug_self_test(void) {
   /* print a value of expression. returns `()` */
   /* NOTE: it's tentative and will be removed when I/O library ready. */
   assert(pug_parseTest("let f = |x| 2 * x; print (f 10);"));
+
+  /* operator symbol may be used as a variable */
+  assert(pug_parseTest("let (+++) = |a b| a+b; (+++) 2 3 == 5"));
 }


### PR DESCRIPTION
A parenthesized operator symbol may be used as a variable.
NOTE: That operator symbol cannot be used as an unary/binary operator for now.

for example:
~~~
let (+++) = |a b| a + b;
(+++) 5 6;  // -> 11
5 +++ 5;    // -> syntax error
~~~
