### PR TITLE
spec changed: `let a = b` does not evaluate `b`.

### DIFF
--- a/example/pug-lang/include/types/Context.h
+++ b/example/pug-lang/include/types/Context.h
@@ -21,8 +21,7 @@ typedef struct ContextT {
   Context (*branch)(Context ctx); ///< creates branced context
   Context (*nested)(Context ctx); ///< creates nested (inner) context
   struct {
-    MapEntry* (*lookupEx)(Context ctx, String ident);
-    Maybe(Expr) (*lookup)(Context ctx, String ident);
+    MapEntry* (*lookup)(Context ctx, String ident);
     void (*put)(Context ctx, String ident, Expr e);
   } map;
 } ContextT;
@@ -57,7 +56,7 @@ static Context FUNC_NAME(nested, Context)(Context c) {
   return ctx;
 }
 
-static MapEntry* FUNC_NAME(lookupEx, Context)(Context ctx, String ident) {
+static MapEntry* FUNC_NAME(lookup, Context)(Context ctx, String ident) {
   ListT(MapEntry) L = trait(List(MapEntry));
   while (ctx) {
     for (List(MapEntry) xs = ctx->map; !L.null(xs); xs = L.tail(xs)) {
@@ -71,20 +70,6 @@ static MapEntry* FUNC_NAME(lookupEx, Context)(Context ctx, String ident) {
   return NULL;
 }
 
-static Maybe(Expr) FUNC_NAME(lookup, Context)(Context ctx, String ident) {
-  ListT(MapEntry) L = trait(List(MapEntry));
-  while (ctx) {
-    for (List(MapEntry) xs = ctx->map; !L.null(xs); xs = L.tail(xs)) {
-      MapEntry x = L.head(xs);
-      if (g_eq(x.ident, ident)) {
-        return (Maybe(Expr)){.value = x.e};
-      }
-    }
-    ctx = ctx->outer;
-  }
-  return (Maybe(Expr)){.none = true};
-}
-
 static void FUNC_NAME(put, Context)(Context ctx, String ident, Expr e) {
   MapEntry entry = {.ident = ident, .e = e};
   ctx->map = trait(List(MapEntry)).cons(entry, ctx->map);
@@ -95,7 +80,6 @@ ContextT Trait(Context) {
       .create = FUNC_NAME(create, Context),
       .branch = FUNC_NAME(branch, Context),
       .nested = FUNC_NAME(nested, Context),
-      .map.lookupEx = FUNC_NAME(lookupEx, Context),
       .map.lookup = FUNC_NAME(lookup, Context),
       .map.put = FUNC_NAME(put, Context),
   };

--- a/example/pug-lang/src/interpreter/interpreter.c
+++ b/example/pug-lang/src/interpreter/interpreter.c
@@ -81,10 +81,10 @@ static EvalResult eval_apply(Context ctx, Expr x) {
     RETURN_ERR("function application");
   }
   /* TODO: what should be done to do lazy evaluation? */
-  EVAL(ctx, x->rhs, a); // <-
-  ContextT C = trait(Context);
+  EVAL(ctx, x->rhs, a);          // <-
   Expr v = f.ok->lambda->lhs;    // (Var v)
   Expr body = f.ok->lambda->rhs; // body
+  ContextT C = trait(Context);
   Context c = C.branch(f.ok->ctx);
   C.map.put(c, v->var.ident, a.ok);
   RETURN_DEFERED(c, body);
@@ -121,10 +121,9 @@ static EvalResult eval_seq(Context ctx, Expr x) {
 static EvalResult eval_let(Context ctx, Expr x) {
   ContextT C = trait(Context);
   assert(x->lhs->kind == VAR);
-  EVAL(ctx, x->rhs, rhs);
   // if the previous definiton exists, it will be shadowed.
-  C.map.put(ctx, x->lhs->var.ident, rhs.ok);
-  RETURN_OK(rhs.ok);
+  C.map.put(ctx, x->lhs->var.ident, x->rhs);
+  RETURN_OK(x->rhs);
 }
 
 static EvalResult eval_assign(Context ctx, Expr x) {
@@ -181,11 +180,13 @@ static EvalResult eval_not(Context ctx, Expr x) {
 
 static EvalResult eval_var(Context ctx, Expr x) {
   ContextT C = trait(Context);
-  Maybe(Expr) m = C.map.lookup(ctx, x->var.ident);
-  if (m.none) {
+  MapEntry* m = C.map.lookupEx(ctx, x->var.ident);
+  if (!m) {
     RETURN_ERR("Undefined variable");
   }
-  RETURN_OK(m.value);
+  EVAL(ctx, m->e, val);
+  m->e = val.ok; /* replace with evaluated value */
+  RETURN_OK(val.ok);
 }
 
 // -----------------------------------------------------------------------

--- a/example/pug-lang/src/interpreter/interpreter.c
+++ b/example/pug-lang/src/interpreter/interpreter.c
@@ -180,7 +180,7 @@ static EvalResult eval_not(Context ctx, Expr x) {
 
 static EvalResult eval_var(Context ctx, Expr x) {
   ContextT C = trait(Context);
-  MapEntry* m = C.map.lookupEx(ctx, x->var.ident);
+  MapEntry* m = C.map.lookup(ctx, x->var.ident);
   if (!m) {
     RETURN_ERR("Undefined variable");
   }

--- a/example/pug-lang/src/test.c
+++ b/example/pug-lang/src/test.c
@@ -73,7 +73,8 @@ void pug_self_test(void) {
 
   /* evaluating an undefined variable is not permitted. */
   assert(!pug_parseTest("a"));         /* Undefined variable */
-  assert(!pug_parseTest("let a = a")); /* Undefined variable */
+  assert(pug_parseTest("let a = a"));  /* -> (Var a) */
+  /* NOTE right-hand side is not evaluated. */
 
   /* assignment expression results the value assigned. */
   assert(pug_parseTest("let a = 1; a = 100")); /* 100 */
@@ -174,8 +175,10 @@ void pug_self_test(void) {
    * variables defined after the block in outer block are NOT accessible.
    * (block's scope isn't a **nested scope** but a **branched scope**)
    */
-  assert(!pug_parseTest("{let y = z}; let z = 2"));
+  assert(!pug_parseTest("{z}; let z = 2"));
   // -> Undefined variable
+  assert(pug_parseTest("{let y = z}; let z = 2")); /* 2 */
+  // NOTE `z` in the block is never evaluated
 
   /*
    * From outside a block,


### PR DESCRIPTION
At this commit:
- `let a = b` defines variable `a` that just points expression `b`.
- expression `b` is not evaluated. (evaluation is defered)
- when variable `a` is evaluated,
  its value is replaced with evaluation result of `b`:
  (1) `b` will be evaluated.
  (2) `a` points the result of (1) instead of expression `b`.