### PR TITLE
example/pug-lang/list

### DIFF
--- a/example/pug-lang/README.org
+++ b/example/pug-lang/README.org
@@ -79,6 +79,14 @@ let fact = |x| {
 };
 #+end_src
 
+* Sample code
+
+See also sample code in the [[file:example/][example]] folder.
+- [[file:example/fact.txt][factorial function]]
+- [[file:example/fib.txt][fibonacci number]]
+- [[file:example/list.txt][list and folding functions]]
+
+
 * Pug programming language
 
 - [[file:docs/syntax.md][Syntax]] :: Declaratons, Expressions, Operators syntax.

--- a/example/pug-lang/example/fact.txt
+++ b/example/pug-lang/example/fact.txt
@@ -1,0 +1,31 @@
+// -*- coding: utf-8-unix -*-
+
+// Here are three implementations of `factorial` function.
+//
+// NOTE: The argument `x` should be `x <= 20`,
+//       otherwise calculation overflows.
+//       (21! is too large for 64bit integer)
+
+// factorial
+let fact1 = |x|
+  if x <=1 {
+    1
+  } else {
+    x * fact (x-1)
+  }
+;
+
+// factorial (tail recursive call version)
+let fact2 = |x| {
+  let f = |x a| {
+    print a;
+    if x <= 1 {
+      a
+    } else {
+      f (x-1) (x*a)
+    }
+  };
+  f x 1
+};
+
+let fact = fact2;

--- a/example/pug-lang/example/fib.txt
+++ b/example/pug-lang/example/fib.txt
@@ -1,0 +1,15 @@
+// -*- coding: utf-8-unix -*-
+
+// `fib n` calculates `n`th fibonacci number (n>=0)
+let fib = |n| {
+  let f = |n a b| {
+    if n == 0 {
+      1
+    } else if n == 1 {
+      a
+    } else {
+      f (n-1) (a+b) a
+    }
+  };
+  f n 1 1;
+};

--- a/example/pug-lang/example/list.txt
+++ b/example/pug-lang/example/list.txt
@@ -1,0 +1,43 @@
+// -*- coding: utf-8-unix -*-
+
+let cons = |x xs| |y|
+  if y == 0 {
+    x
+  } else {
+    xs
+  }
+;
+
+let nil = |_| nil;
+
+let null = |xs| xs == nil;
+let head = |xs| xs 0;
+let tail = |xs| xs 1;
+
+let foldr = |f a xs|
+  if (null xs) {
+    a
+  } else {
+    f (head xs) (foldr f a (tail xs))
+  }
+;
+
+let foldl = |f a xs|
+  if (null xs) {
+    a
+  } else {
+    foldl f (f a (head xs)) (tail xs)
+  }
+;
+
+// Example:
+// -------------------------------------------------------------
+let (+) = |a b| a + b;
+let sub = |a b| a - b;
+
+let xs = cons 3 (cons 2 (cons 1 nil));
+
+print (foldr (+) 0 xs);         // -> 6
+print (foldl (+) 0 xs);         // -> 6
+print (foldr sub 0 xs);         // -> 3 - (2 - (1 - 0)) -> 2
+print (foldl sub 0 xs);         // -> ((0 - 3) - 2) - 1 -> -6

--- a/example/pug-lang/src/interpreter/interpreter.c
+++ b/example/pug-lang/src/interpreter/interpreter.c
@@ -39,6 +39,10 @@ Interpreter(Expr) Trait(Interpreter(Expr)) {
       bool x = lhs.ok->kind _op_ rhs.ok->kind;                           \
       RETURN_OK(trait(Expr).boolean(x));                                 \
     }                                                                    \
+    case CLOSURE: {                                                      \
+      bool x = lhs.ok _op_ rhs.ok;                                       \
+      RETURN_OK(trait(Expr).boolean(x));                                 \
+    }                                                                    \
     default:                                                             \
       RETURN_ERR("Type error");                                          \
     }                                                                    \


### PR DESCRIPTION
Now `list` can be implemented, even though no any container type is available.