### PR TITLE
Remove assignment expression

### DIFF
--- a/example/pug-lang/docs/syntax.md
+++ b/example/pug-lang/docs/syntax.md
@@ -91,7 +91,6 @@ expr;              // ok
 
 | Operator                  | Associativity     | Example                             | Explanation                         |
 | ------------------------- | ----------------- | ----------------------------------- | ----------------------------------- |
-| `=`                       | non-associative   | `x = expr`                          | assignment                          |
 | <code>&#124;&#124;</code> | right-associative | <code>expr &#124;&#124; expr</code> | logical OR                          |
 | `&&`                      | right-associative | `expr && expr`                      | logical AND                         |
 | `==`                      | non-associative   | `expr == expr`                      | equality comparison                 |

--- a/example/pug-lang/include/parser/expr.h
+++ b/example/pug-lang/include/parser/expr.h
@@ -11,8 +11,7 @@
 
 C_API_BEGIN
 
-// expr   = assign
-// assign = expr0 {"=" expr0}
+// expr   = expr0
 // expr0  = expr1
 // expr1  = expr2
 // expr2  = expr3 {"||" expr3}
@@ -108,8 +107,6 @@ C_API_BEGIN
 //             | "/" | "?"
 
 PARSER(Expr) expr(void);
-PARSER(Expr) assign(void);
-
 PARSER(Expr) expr0(void);
 PARSER(Expr) expr1(void);
 PARSER(Expr) expr2(void);

--- a/example/pug-lang/include/types/Expr.h
+++ b/example/pug-lang/include/types/Expr.h
@@ -39,8 +39,6 @@ enum ExprId {
   TYPE,
   /* let (define a variable) */
   LET,
-  /* assignment */
-  ASSIGN,
   /* logical and/or */
   OR,
   AND,
@@ -119,7 +117,6 @@ typedef struct ExprT {
   Expr (*seq)(Expr lhs, Expr rhs);         /* list of statements */
   Expr (*declvar)(Expr lhs, Expr rhs);     /* variable declaration */
   Expr (*let)(Expr lhs, Expr rhs);         /* variable definition */
-  Expr (*assign)(Expr lhs, Expr rhs);      /* assignment */
   Expr (*logic_or)(Expr lhs, Expr rhs);    /* logical or */
   Expr (*logic_and)(Expr lhs, Expr rhs);   /* logical and */
   Expr (*eq)(Expr lhs, Expr rhs);          /* equality */

--- a/example/pug-lang/src/interpreter/interpreter.c
+++ b/example/pug-lang/src/interpreter/interpreter.c
@@ -200,17 +200,6 @@ static EvalResult eval_declvar(Context ctx, Expr x) {
   RETURN_OK(x->rhs);
 }
 
-static EvalResult eval_assign(Context ctx, Expr x) {
-  ContextT C = trait(Context);
-  ExprT E = trait(Expr);
-  assert(x->lhs->id == VAR);
-  EVAL(ctx, x->rhs, rhs);
-  EVAL(ctx, x->lhs, lhs);
-  // the previous definiton will be shadowed.
-  C.map.put(ctx, x->lhs->ident, E.thunk(ctx, rhs.ok));
-  RETURN_OK(rhs.ok);
-}
-
 static EvalResult eval_logical_AND_OR(Context ctx, Expr x) {
   EVAL(ctx, x->lhs, lhs);
   assert(lhs.ok->id == LITERAL);
@@ -279,8 +268,6 @@ static EvalResult eval_expr1(Context ctx, Expr x) {
     return eval_seq(ctx, x);
   case LET:
     return eval_let(ctx, x);
-  case ASSIGN:
-    return eval_assign(ctx, x);
   case OR:
   case AND:
     return eval_logical_AND_OR(ctx, x);

--- a/example/pug-lang/src/parser/expr.c
+++ b/example/pug-lang/src/parser/expr.c
@@ -3,26 +3,7 @@
 #include "parser/expr.h"
 
 PARSER(Expr) expr(void) {
-  return assign();
-}
-
-// PARSER(Expr) assign(void);
-parsec(assign, Expr) {
-  ExprT E = trait(Expr);
-  PARSER(Expr) p = expr0();
-  PARSER(char) op = lexme(char1('='));
-  DO() {
-    SCAN(p, lhs);
-    if (lhs->id != VAR) {
-      RETURN(lhs);
-    }
-    SCAN(optional(op), m);
-    if (m.none) {
-      RETURN(lhs);
-    }
-    SCAN(p, rhs);
-    RETURN(E.assign(lhs, rhs));
-  }
+  return expr0();
 }
 
 PARSER(Expr) expr0(void) {

--- a/example/pug-lang/src/test.c
+++ b/example/pug-lang/src/test.c
@@ -93,12 +93,6 @@ void pug_self_test(void) {
   assert(pug_parseTest("var a : a; let a = a")); /* -> (Var a) */
   /* NOTE right-hand side is not evaluated. */
 
-  /* assignment expression results the value assigned. */
-  assert(pug_parseTest("let a = 1; a = 100")); /* 100 */
-
-  /* assignment of different type is not permitted. */
-  assert(!pug_parseTest("let a = 1; a = ()")); /* Type mismatch */
-
   /* comparison operators results `true` or `false` */
   assert(pug_parseTest("1 == 1"));                     /* true */
   assert(pug_parseTest("0 == 1"));                     /* false */
@@ -175,8 +169,6 @@ void pug_self_test(void) {
   assert(pug_parseTest("let a = 1; let b = 2; b"));     /* 2 */
 
   /* a block establishes new **branch** of lexical scope. */
-  assert(pug_parseTest("let x = 1; {x = 2}"));        /* 2 */
-  assert(pug_parseTest("let x = 1; {x = 2}; x"));     /* 1 */
   assert(pug_parseTest("let x = 1; {let x = 2}"));    /* 2 */
   assert(pug_parseTest("let x = 1; {let x = 2}; x")); /* 1 */
 
@@ -241,7 +233,7 @@ void pug_self_test(void) {
    */
   assert(pug_parseTest("let y = 10;\n"
                        "let g = |x| x*y;\n"
-                       "let f = |x| {y = 2; y*y + g x};\n"
+                       "let f = |x| {let y = 2; y*y + g x};\n"
                        "f 3 == 34"));
   // -> true
   // NOTE: (f 3) shall be 10 if dynamic scoping.

--- a/example/pug-lang/src/types/Expr.c
+++ b/example/pug-lang/src/types/Expr.c
@@ -86,9 +86,6 @@ static Expr FUNC_NAME(declvar, Expr)(Expr lhs, Expr rhs) {
 static Expr FUNC_NAME(let, Expr)(Expr lhs, Expr rhs) {
   return Expr_Binary(LET, lhs, rhs);
 }
-static Expr FUNC_NAME(assign, Expr)(Expr lhs, Expr rhs) {
-  return Expr_Binary(ASSIGN, lhs, rhs);
-}
 static Expr FUNC_NAME(logic_or, Expr)(Expr lhs, Expr rhs) {
   return Expr_Binary(OR, lhs, rhs);
 }
@@ -193,7 +190,6 @@ ExprT Trait(Expr) {
       .seq = FUNC_NAME(seq, Expr),
       .declvar = FUNC_NAME(declvar, Expr),
       .let = FUNC_NAME(let, Expr),
-      .assign = FUNC_NAME(assign, Expr),
       .logic_or = FUNC_NAME(logic_or, Expr),
       .logic_and = FUNC_NAME(logic_and, Expr),
       .eq = FUNC_NAME(eq, Expr),
@@ -278,9 +274,6 @@ show_user_type(Expr)(CharBuff* b, Expr x) {
     break;
   case LET:
     Expr_showBinary(b, "Let", x->lhs, x->rhs);
-    break;
-  case ASSIGN:
-    Expr_showBinary(b, "Assign", x->lhs, x->rhs);
     break;
   case OR:
     Expr_showBinary(b, "Or", x->lhs, x->rhs);

--- a/example/pug-lang/src/types/Infer.c
+++ b/example/pug-lang/src/types/Infer.c
@@ -347,16 +347,6 @@ action(tiExprDeclvar, List(Assump), Expr, Tup(List(Pred), Type)) {
   }
 }
 
-action(tiExprAssign, List(Assump), Expr, Tup(List(Pred), Type)) {
-  A_DO_WITH(as, e) {
-    A_RUN(tiExpr(as, e->lhs), a);
-    A_RUN(tiExpr(as, e->rhs), b);
-    A_RUN(unify(a.t, b.t));
-    List(Pred) ps = appendPreds(a.ps, b.ps);
-    A_RETURN(tupPsT(ps, a.t));
-  }
-}
-
 action(tiExprLet, List(Assump), Expr, Tup(List(Pred), Type)) {
   A_DO_WITH(as, e) {
     Maybe(Scheme) sc = t_find(e->lhs->ident, as);
@@ -488,8 +478,6 @@ static ACTION(Tup(List(Pred), Type)) tiExpr0(List(Assump) as, Expr e) {
     return tiExprSeq(as, e);
   case DECLVAR:
     return tiExprDeclvar(as, e);
-  case ASSIGN:
-    return tiExprAssign(as, e);
   case LET:
     return tiExprLet(as, e);
   case OR:


### PR DESCRIPTION
### Language spec changed : Removed assignment expression.

Assignment expression is needless and not so useful.
Use `let` declaration instead.
