### PR TITLE
[VM] improved memory usage

### DIFF
--- a/example/vm/include/vm/stack.h
+++ b/example/vm/include/vm/stack.h
@@ -1,0 +1,16 @@
+/* -*- coding: utf-8-unix -*- */
+#pragma once
+
+#include <cparsec3/base/base.h>
+
+#define Stack(T) TYPE_NAME(Stack, T)
+
+#define trait_Stack(T)                                                   \
+  C_API_BEGIN                                                            \
+  typedef struct Stack(T) Stack(T);                                      \
+  struct Stack(T) {                                                      \
+    Array(T) array; /* used + unused memory block */                     \
+    size_t size;    /* size of used area */                              \
+  };                                                                     \
+  C_API_END                                                              \
+  END_OF_STATEMENTS

--- a/example/vm/src/vm/debug.c
+++ b/example/vm/src/vm/debug.c
@@ -29,7 +29,7 @@ inline static void printTerm(Term t) {
 }
 
 static void printEnv(Env es) {
-  /* printf("%p: ", (void*)es); */
+  printf("%p:", (void*)es);
   printf("[");
   if (es) {
     printf("%zu", (size_t)es->head);
@@ -52,17 +52,36 @@ inline static void printUpdate(Update u) {
 }
 
 static void printUStack(UStack us) {
-  /* printf("%p: ", (void*)us); */
   printf("[");
-  if (us) {
-    printUpdate(us->head);
-    while (us->tail) {
-      us = us->tail;
+  if (us.size) {
+    printUpdate(us.array.data[--us.size]);
+    while (us.size) {
       printf(", ");
-      printUpdate(us->head);
+      printUpdate(us.array.data[--us.size]);
     }
   }
   printf("]");
+}
+
+static void dumpHeap(Heap h) {
+  printf("vm: heap used %zu / %zu\n", h.size, h.array.length);
+  for (size_t a = 0; a < h.size; ++a) {
+    printf("%5zu.t : ", a);
+    printTerm(h.array.data[a].t);
+    printf("\n");
+    printf("%5s.es: ", "");
+    printEnv(h.array.data[a].es);
+    printf("\n");
+  }
+}
+
+static void dumpCellHeap(CellHeap ch) {
+  printf("vm: cell heap used %zu / %zu\n", ch.size, ch.array.length);
+  for (size_t i = 0; i < ch.size; ++i) {
+    Cell* p = &ch.array.data[i];
+    printf("    ");
+    printf("%p:{head:%zu, tail:%p}\n", (void*)p, p->head, (void*)p->tail);
+  }
 }
 
 void dumpVMState(VMState s) {
@@ -78,14 +97,7 @@ void dumpVMState(VMState s) {
   printf("vm:   us: ");
   printUStack(s.us);
   printf("\n");
-  printf("vm: heap used %zu / %zu\n", s.h.size, s.h.array.length);
-  for (size_t a = 0; a < s.h.size; ++a) {
-    printf("%5zu.t : ", a);
-    printTerm(s.h.array.data[a].t);
-    printf("\n");
-    printf("%5s.es: ", "");
-    printEnv(s.h.array.data[a].es);
-    printf("\n");
-  }
+  dumpHeap(s.h);
+  dumpCellHeap(s.cellHeap);
   printf("\n");
 }


### PR DESCRIPTION
- added `Stack(T)`
- re-defined `UStack` as `Stack(Update)` instead of `List(Update)`
- re-defined `Heap` as `Stack(Closure)` instead of `struct Heap`
- defined `CellHeap` as `Stack(Cell)`,
  that is set of used/unused memory cells of `List(Adr)`
- defined `Cell` as `stList(Adr)` that is a memory cell of `List(Adr)`
- added custom-made list constructor `cons(Adr, List(Adr), CellHeap*)`
- all memory cell of `List(Adr)` is allocated from `CellHeap`,
  all of them are traceable now.
- literal's environment is omitted. (no environment is needed for literal)
- literals in the `Heap` are no longer updated. (no need to update literal)